### PR TITLE
feat: Add CLI tool for remote indexing

### DIFF
--- a/Grigori.slnx
+++ b/Grigori.slnx
@@ -6,5 +6,6 @@
     <Project Path="src/Grigori.Infrastructure/Grigori.Infrastructure.csproj" />
     <Project Path="src/Grigori.Mcp/Grigori.Mcp.csproj" />
     <Project Path="src/Grigori.Api/Grigori.Api.csproj" />
+    <Project Path="src/Grigori.Cli/Grigori.Cli.csproj" />
   </Folder>
 </Solution>

--- a/src/Grigori.Cli/FileCollector.cs
+++ b/src/Grigori.Cli/FileCollector.cs
@@ -1,0 +1,193 @@
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+
+namespace Grigori.Cli;
+
+public class FileCollector
+{
+    private readonly string _rootPath;
+    private readonly HashSet<string> _gitignorePatterns = [];
+
+    // Default patterns to always exclude
+    private static readonly string[] DefaultExcludes =
+    [
+        // Version control
+        ".git/**",
+        ".svn/**",
+        ".hg/**",
+
+        // Dependencies
+        "node_modules/**",
+        "vendor/**",
+        "packages/**",
+
+        // Build outputs
+        "bin/**",
+        "obj/**",
+        "dist/**",
+        "build/**",
+        "out/**",
+        "target/**",
+
+        // IDE/Editor
+        ".vs/**",
+        ".vscode/**",
+        ".idea/**",
+        "*.suo",
+        "*.user",
+
+        // Package managers
+        "*.nupkg",
+        "*.zip",
+        "*.tar.gz",
+
+        // Binary files
+        "*.exe",
+        "*.dll",
+        "*.so",
+        "*.dylib",
+        "*.pdb",
+
+        // Images
+        "*.png",
+        "*.jpg",
+        "*.jpeg",
+        "*.gif",
+        "*.ico",
+        "*.svg",
+        "*.webp",
+
+        // Other
+        "*.min.js",
+        "*.min.css",
+        "*.map",
+        ".DS_Store",
+        "Thumbs.db"
+    ];
+
+    // File extensions to include (code files)
+    private static readonly string[] IncludeExtensions =
+    [
+        // C#/.NET
+        ".cs", ".csproj", ".sln", ".slnx", ".razor", ".cshtml",
+
+        // Web
+        ".ts", ".tsx", ".js", ".jsx", ".vue", ".svelte",
+        ".html", ".css", ".scss", ".sass", ".less",
+
+        // Data/Config
+        ".json", ".yaml", ".yml", ".xml", ".toml",
+
+        // Documentation
+        ".md", ".txt", ".rst",
+
+        // Other languages
+        ".py", ".rb", ".go", ".rs", ".java", ".kt", ".scala",
+        ".c", ".cpp", ".h", ".hpp", ".swift", ".m",
+        ".php", ".lua", ".sh", ".bash", ".ps1", ".psm1",
+        ".sql", ".graphql", ".proto",
+
+        // Config
+        ".env.example", ".gitignore", ".dockerignore",
+        "Dockerfile", "Makefile", "CMakeLists.txt"
+    ];
+
+    public FileCollector(string rootPath)
+    {
+        _rootPath = Path.GetFullPath(rootPath);
+        LoadGitignore();
+    }
+
+    private void LoadGitignore()
+    {
+        var gitignorePath = Path.Combine(_rootPath, ".gitignore");
+        if (!File.Exists(gitignorePath)) return;
+
+        foreach (var line in File.ReadLines(gitignorePath))
+        {
+            var trimmed = line.Trim();
+            if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith('#'))
+                continue;
+
+            // Convert gitignore pattern to glob pattern
+            var pattern = trimmed;
+
+            // If pattern doesn't start with /, it can match anywhere
+            if (!pattern.StartsWith('/'))
+            {
+                pattern = "**/" + pattern;
+            }
+            else
+            {
+                pattern = pattern.TrimStart('/');
+            }
+
+            // If pattern ends with /, it's a directory
+            if (pattern.EndsWith('/'))
+            {
+                pattern += "**";
+            }
+
+            _gitignorePatterns.Add(pattern);
+        }
+    }
+
+    public List<FileContent> CollectFiles()
+    {
+        var matcher = new Matcher();
+
+        // Add all file patterns
+        foreach (var ext in IncludeExtensions)
+        {
+            if (ext.StartsWith('.'))
+                matcher.AddInclude($"**/*{ext}");
+            else
+                matcher.AddInclude($"**/{ext}");
+        }
+
+        // Add default excludes
+        foreach (var pattern in DefaultExcludes)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        // Add gitignore excludes
+        foreach (var pattern in _gitignorePatterns)
+        {
+            matcher.AddExclude(pattern);
+        }
+
+        var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(_rootPath)));
+        var files = new List<FileContent>();
+
+        foreach (var match in result.Files)
+        {
+            var fullPath = Path.Combine(_rootPath, match.Path);
+
+            try
+            {
+                // Skip files larger than 1MB
+                var fileInfo = new FileInfo(fullPath);
+                if (fileInfo.Length > 1024 * 1024)
+                    continue;
+
+                var content = File.ReadAllText(fullPath);
+
+                // Skip binary-looking files
+                if (content.Contains('\0'))
+                    continue;
+
+                files.Add(new FileContent(
+                    match.Path.Replace('\\', '/'),
+                    content
+                ));
+            }
+            catch
+            {
+                // Skip files we can't read
+            }
+        }
+
+        return files;
+    }
+}

--- a/src/Grigori.Cli/Grigori.Cli.csproj
+++ b/src/Grigori.Cli/Grigori.Cli.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- Native AOT -->
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!-- Tool configuration -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>grigori</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageId>Grigori.Cli</PackageId>
+    <Version>1.0.0</Version>
+    <Description>CLI tool for indexing projects to a Grigori semantic search server</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Grigori.Cli/GrigoriClient.cs
+++ b/src/Grigori.Cli/GrigoriClient.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Grigori.Cli;
+
+public class GrigoriClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    public GrigoriClient(string baseUrl)
+    {
+        _baseUrl = baseUrl.TrimEnd('/');
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(10) // Long timeout for large projects
+        };
+    }
+
+    public async Task<IndexFilesResponse> IndexFilesAsync(
+        string projectName,
+        List<FileContent> files,
+        Action<int>? onProgress = null)
+    {
+        try
+        {
+            var request = new IndexFilesRequest(files);
+
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{_baseUrl}/api/index/files",
+                request,
+                JsonContext.Default.IndexFilesRequest
+            );
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                return new IndexFilesResponse(false, 0, 0, 0, $"HTTP {(int)response.StatusCode}: {error}");
+            }
+
+            var result = await response.Content.ReadFromJsonAsync(JsonContext.Default.IndexFilesResponse);
+
+            onProgress?.Invoke(100);
+
+            return result ?? new IndexFilesResponse(false, 0, 0, 0, "Empty response from server");
+        }
+        catch (HttpRequestException ex)
+        {
+            return new IndexFilesResponse(false, 0, 0, 0, $"Connection failed: {ex.Message}");
+        }
+        catch (TaskCanceledException)
+        {
+            return new IndexFilesResponse(false, 0, 0, 0, "Request timed out");
+        }
+        catch (Exception ex)
+        {
+            return new IndexFilesResponse(false, 0, 0, 0, ex.Message);
+        }
+    }
+
+    public async Task<bool> HealthCheckAsync()
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"{_baseUrl}/api/health");
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Grigori.Cli/JsonContext.cs
+++ b/src/Grigori.Cli/JsonContext.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Grigori.Cli;
+
+[JsonSerializable(typeof(IndexFilesRequest))]
+[JsonSerializable(typeof(IndexFilesResponse))]
+[JsonSerializable(typeof(List<FileContent>))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class JsonContext : JsonSerializerContext
+{
+}
+
+public record FileContent(string RelativePath, string Content);
+
+public record IndexFilesRequest(List<FileContent> Files);
+
+public record IndexFilesResponse(
+    bool Success,
+    int FilesIndexed,
+    int ChunksCreated,
+    long DurationMs,
+    string? Error
+);

--- a/src/Grigori.Cli/Program.cs
+++ b/src/Grigori.Cli/Program.cs
@@ -1,0 +1,121 @@
+using Grigori.Cli;
+
+// ANSI color codes
+const string Reset = "\x1b[0m";
+const string Cyan = "\x1b[36m";
+const string Green = "\x1b[32m";
+const string Red = "\x1b[31m";
+const string Yellow = "\x1b[33m";
+const string Dim = "\x1b[90m";
+
+// Parse arguments
+var server = "http://localhost:5151";
+var path = ".";
+var showHelp = false;
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "-s":
+        case "--server":
+            if (i + 1 < args.Length)
+                server = args[++i];
+            break;
+        case "-h":
+        case "--help":
+            showHelp = true;
+            break;
+        case "index":
+            // Next non-flag arg is the path
+            if (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
+                path = args[++i];
+            break;
+        default:
+            if (!args[i].StartsWith('-') && i == 0)
+            {
+                // First arg without dash could be a command or path
+                if (args[i] != "index")
+                    path = args[i];
+            }
+            break;
+    }
+}
+
+if (showHelp || args.Length == 0)
+{
+    Console.WriteLine($"""
+        {Cyan}Grigori CLI{Reset} - Index projects to a Grigori semantic search server
+
+        {Yellow}Usage:{Reset}
+          grigori index [path] [options]
+
+        {Yellow}Arguments:{Reset}
+          path                  Path to the project directory (default: current directory)
+
+        {Yellow}Options:{Reset}
+          -s, --server <url>    Grigori server URL (default: http://localhost:5151)
+          -h, --help            Show help information
+
+        {Yellow}Examples:{Reset}
+          grigori index                     Index current directory
+          grigori index ./my-project        Index specific directory
+          grigori index . -s http://grigori:5151   Use custom server
+        """);
+    return 0;
+}
+
+// Resolve path
+var absolutePath = Path.GetFullPath(path);
+var projectName = Path.GetFileName(absolutePath);
+
+if (!Directory.Exists(absolutePath))
+{
+    Console.WriteLine($"{Red}Error:{Reset} Directory not found: {absolutePath}");
+    return 1;
+}
+
+Console.WriteLine($"{Cyan}Indexing:{Reset} {absolutePath}");
+Console.WriteLine($"{Cyan}Project:{Reset} {projectName}");
+Console.WriteLine($"{Cyan}Server:{Reset} {server}");
+Console.WriteLine();
+
+// Check server health
+var client = new GrigoriClient(server);
+Console.Write($"{Dim}Checking server...{Reset}");
+
+if (!await client.HealthCheckAsync())
+{
+    Console.WriteLine($"\r{Red}Error:{Reset} Cannot connect to Grigori server at {server}");
+    Console.WriteLine($"{Dim}Make sure the Grigori Docker container is running:{Reset}");
+    Console.WriteLine($"  docker run -d -p 5151:5151 grigori");
+    return 1;
+}
+Console.WriteLine($"\r{Green}Server online{Reset}              ");
+
+// Collect files
+Console.Write($"{Dim}Collecting files...{Reset}");
+var collector = new FileCollector(absolutePath);
+var files = collector.CollectFiles();
+Console.WriteLine($"\r{Green}Found:{Reset} {files.Count} files          ");
+
+if (files.Count == 0)
+{
+    Console.WriteLine($"{Yellow}No files to index.{Reset}");
+    return 0;
+}
+
+// Send to server
+Console.Write($"{Dim}Indexing...{Reset}");
+var result = await client.IndexFilesAsync(projectName, files);
+
+if (result.Success)
+{
+    Console.WriteLine($"\r{Green}Success!{Reset} Indexed {result.FilesIndexed} files with {result.ChunksCreated} chunks in {result.DurationMs}ms");
+    return 0;
+}
+else
+{
+    Console.WriteLine($"\r{Red}Error:{Reset} {result.Error}");
+    return 1;
+}


### PR DESCRIPTION
## Summary
- Adds `Grigori.Cli` - a Native AOT compatible CLI tool for indexing projects to a Grigori Docker container
- Client-side file filtering (node_modules, bin, .git, etc.) keeps Grigori server language/framework agnostic
- .gitignore support for respecting project exclusions

## Features
- **Native AOT Compatible**: Uses source-generated JSON serialization, no reflection
- **Smart Filtering**: Built-in patterns for common excludes (node_modules, bin, obj, .git, IDE files, binaries, images)
- **Gitignore Support**: Automatically reads and respects .gitignore patterns
- **Health Check**: Verifies server connectivity before attempting to index
- **Colored Output**: ANSI colors for better terminal experience

## Usage
```bash
# Index current directory
grigori index

# Index specific directory
grigori index ./my-project

# Use custom server URL
grigori index . -s http://grigori:5151
```

## Test plan
- [x] Built and tested locally
- [x] Indexed Grigori.Cli project to running Docker container
- [x] Verified file filtering works (skips bin, obj, etc.)
- [ ] Verify Native AOT publish works on machine with VS tooling

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)