### PR TITLE
fix: Pass project name from CLI to server for correct display

### DIFF
--- a/src/Grigori.Cli/GrigoriClient.cs
+++ b/src/Grigori.Cli/GrigoriClient.cs
@@ -24,7 +24,7 @@ public class GrigoriClient
     {
         try
         {
-            var request = new IndexFilesRequest(files);
+            var request = new IndexFilesRequest(projectName, files);
 
             var response = await _httpClient.PostAsJsonAsync(
                 $"{_baseUrl}/api/index/files",

--- a/src/Grigori.Cli/JsonContext.cs
+++ b/src/Grigori.Cli/JsonContext.cs
@@ -12,7 +12,7 @@ internal partial class JsonContext : JsonSerializerContext
 
 public record FileContent(string RelativePath, string Content);
 
-public record IndexFilesRequest(List<FileContent> Files);
+public record IndexFilesRequest(string ProjectName, List<FileContent> Files);
 
 public record IndexFilesResponse(
     bool Success,

--- a/src/Grigori.Contracts/Dtos/Index/IndexRequestDto.cs
+++ b/src/Grigori.Contracts/Dtos/Index/IndexRequestDto.cs
@@ -3,4 +3,10 @@ namespace Grigori.Contracts.Dtos.Index;
 public record IndexRequestDto
 {
     public required string Path { get; init; }
+
+    /// <summary>
+    /// Optional project name to use for file paths instead of deriving from the directory.
+    /// When set, file paths will be stored as "ProjectName/relative/path" instead of full paths.
+    /// </summary>
+    public string? ProjectName { get; init; }
 }

--- a/src/Grigori.Mcp/Features/Index/Services/IndexService.cs
+++ b/src/Grigori.Mcp/Features/Index/Services/IndexService.cs
@@ -85,7 +85,15 @@ public class IndexService : IIndexService
             {
                 try
                 {
-                    var result = await IndexFileCoreAsync(file, cancellationToken);
+                    // If ProjectName is set, use it to create a clean path like "ProjectName/relative/path"
+                    var storedPath = file;
+                    if (!string.IsNullOrEmpty(request.ProjectName))
+                    {
+                        var relativePath = Path.GetRelativePath(request.Path, file).Replace('\\', '/');
+                        storedPath = $"{request.ProjectName}/{relativePath}";
+                    }
+
+                    var result = await IndexFileCoreAsync(file, storedPath, cancellationToken);
                     if (result.IsSuccess && result.Value > 0)
                     {
                         totalFilesIndexed++;
@@ -133,7 +141,7 @@ public class IndexService : IIndexService
 
         try
         {
-            var chunkCount = await IndexFileCoreAsync(filePath, cancellationToken);
+            var chunkCount = await IndexFileCoreAsync(filePath, filePath, cancellationToken);
             if (chunkCount.IsFailure)
             {
                 return chunkCount.Error;
@@ -172,23 +180,24 @@ public class IndexService : IIndexService
         return result.Value;
     }
 
-    private async Task<Result<int, GrigoriError>> IndexFileCoreAsync(string filePath, CancellationToken cancellationToken)
+    private async Task<Result<int, GrigoriError>> IndexFileCoreAsync(string filePath, string storedPath, CancellationToken cancellationToken)
     {
         var content = await File.ReadAllTextAsync(filePath, cancellationToken);
         var contentHash = GrigoriDbContext.ComputeHash(content);
 
-        if (await _chunkRepository.HasContentHashAsync(filePath, contentHash, cancellationToken))
+        if (await _chunkRepository.HasContentHashAsync(storedPath, contentHash, cancellationToken))
         {
-            _logger.LogDebug("File already indexed with same content: {FilePath}", filePath);
+            _logger.LogDebug("File already indexed with same content: {FilePath}", storedPath);
             return 0;
         }
 
-        await _chunkRepository.DeleteByFilePathAsync(filePath, cancellationToken);
+        await _chunkRepository.DeleteByFilePathAsync(storedPath, cancellationToken);
 
-        var chunks = _chunkingService.ChunkFile(filePath, content);
+        // Use storedPath for the chunks so the database has clean paths
+        var chunks = _chunkingService.ChunkFile(storedPath, content);
         if (chunks.Count == 0)
         {
-            _logger.LogDebug("No chunks created for: {FilePath}", filePath);
+            _logger.LogDebug("No chunks created for: {FilePath}", storedPath);
             return 0;
         }
 
@@ -210,7 +219,7 @@ public class IndexService : IIndexService
             return insertResult.Error;
         }
 
-        _logger.LogInformation("Indexed {ChunkCount} chunks from {FilePath}", chunks.Count, filePath);
+        _logger.LogInformation("Indexed {ChunkCount} chunks from {FilePath}", chunks.Count, storedPath);
         return chunks.Count;
     }
 

--- a/src/Grigori.Mcp/Program.cs
+++ b/src/Grigori.Mcp/Program.cs
@@ -180,8 +180,11 @@ app.MapPost("/api/index/files", async Task<IResult> (IndexFilesRequest request, 
     if (request.Files is null || request.Files.Count == 0)
         return Results.BadRequest(new { error = "Files are required" });
 
-    // Create temp directory for files
-    var tempDir = Path.Combine(Path.GetTempPath(), "grigori-index", Guid.NewGuid().ToString());
+    // Create temp directory for files using project name if provided
+    var projectFolder = !string.IsNullOrEmpty(request.ProjectName)
+        ? request.ProjectName
+        : Guid.NewGuid().ToString();
+    var tempDir = Path.Combine(Path.GetTempPath(), "grigori-index", projectFolder);
     Directory.CreateDirectory(tempDir);
 
     try
@@ -196,10 +199,11 @@ app.MapPost("/api/index/files", async Task<IResult> (IndexFilesRequest request, 
             await File.WriteAllTextAsync(filePath, file.Content, ct);
         }
 
-        // Index the temp directory
+        // Index the temp directory, passing project name so paths are stored correctly
         var result = await indexService.IndexDirectoryAsync(new IndexRequestDto
         {
-            Path = tempDir
+            Path = tempDir,
+            ProjectName = request.ProjectName
         }, ct);
 
         return result.Match(
@@ -268,5 +272,5 @@ else
 
 record SearchRequest(string Query, int? Limit, string? FileTypes, string? OutputMode);
 record IndexRequest(string Path);
-record IndexFilesRequest(List<FileContent> Files);
+record IndexFilesRequest(string? ProjectName, List<FileContent> Files);
 record FileContent(string RelativePath, string Content);


### PR DESCRIPTION
## Summary
- Fix project name showing as "/" when indexing with `grigori index .`
- CLI now sends the project name to the server
- Server stores file paths as `ProjectName/relative/path` instead of temp directory paths

## Changes
- `Grigori.Cli/JsonContext.cs`: Add `ProjectName` to `IndexFilesRequest`
- `Grigori.Cli/GrigoriClient.cs`: Pass project name in request
- `Grigori.Contracts/Dtos/Index/IndexRequestDto.cs`: Add `ProjectName` field
- `Grigori.Mcp/Program.cs`: Pass project name to IndexService
- `Grigori.Mcp/Features/Index/Services/IndexService.cs`: Store paths with project name prefix

## Test plan
- [x] Run `grigori index . -s http://localhost:8080` from a project directory
- [x] Verify dashboard shows correct project name instead of "/"

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)