### PR TITLE
feat: Stream files in batches instead of single large request

### DIFF
--- a/src/Grigori.Cli/GrigoriClient.cs
+++ b/src/Grigori.Cli/GrigoriClient.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Json;
-using System.Text.Json;
 
 namespace Grigori.Cli;
 
@@ -7,20 +6,93 @@ public class GrigoriClient
 {
     private readonly HttpClient _httpClient;
     private readonly string _baseUrl;
+    private const int DefaultBatchSize = 100;
 
     public GrigoriClient(string baseUrl)
     {
         _baseUrl = baseUrl.TrimEnd('/');
         _httpClient = new HttpClient
         {
-            Timeout = TimeSpan.FromMinutes(10) // Long timeout for large projects
+            Timeout = TimeSpan.FromMinutes(5) // Timeout per batch
         };
+    }
+
+    public async Task<IndexFilesResponse> IndexFilesInBatchesAsync(
+        string projectName,
+        List<FileContent> files,
+        int batchSize = DefaultBatchSize,
+        Action<BatchProgress>? onProgress = null)
+    {
+        if (files.Count == 0)
+        {
+            return new IndexFilesResponse(true, 0, 0, 0, null);
+        }
+
+        var batches = files
+            .Select((file, index) => new { file, index })
+            .GroupBy(x => x.index / batchSize)
+            .Select(g => g.Select(x => x.file).ToList())
+            .ToList();
+
+        var totalFiles = 0;
+        var totalChunks = 0;
+        long totalDuration = 0;
+
+        for (int i = 0; i < batches.Count; i++)
+        {
+            var batch = batches[i];
+
+            onProgress?.Invoke(new BatchProgress(
+                CurrentBatch: i + 1,
+                TotalBatches: batches.Count,
+                FilesInBatch: batch.Count,
+                TotalFiles: files.Count,
+                Status: BatchStatus.Uploading
+            ));
+
+            var result = await IndexFilesAsync(projectName, batch);
+
+            if (!result.Success)
+            {
+                onProgress?.Invoke(new BatchProgress(
+                    CurrentBatch: i + 1,
+                    TotalBatches: batches.Count,
+                    FilesInBatch: batch.Count,
+                    TotalFiles: files.Count,
+                    Status: BatchStatus.Failed,
+                    Error: result.Error
+                ));
+
+                return new IndexFilesResponse(
+                    false,
+                    totalFiles,
+                    totalChunks,
+                    totalDuration,
+                    $"Batch {i + 1}/{batches.Count} failed: {result.Error}"
+                );
+            }
+
+            totalFiles += result.FilesIndexed;
+            totalChunks += result.ChunksCreated;
+            totalDuration += result.DurationMs;
+
+            onProgress?.Invoke(new BatchProgress(
+                CurrentBatch: i + 1,
+                TotalBatches: batches.Count,
+                FilesInBatch: batch.Count,
+                TotalFiles: files.Count,
+                Status: BatchStatus.Completed,
+                FilesIndexed: result.FilesIndexed,
+                ChunksCreated: result.ChunksCreated
+            ));
+        }
+
+        return new IndexFilesResponse(true, totalFiles, totalChunks, totalDuration, null);
     }
 
     public async Task<IndexFilesResponse> IndexFilesAsync(
         string projectName,
-        List<FileContent> files,
-        Action<int>? onProgress = null)
+        List<FileContent> files)
     {
         try
         {
@@ -39,8 +111,6 @@ public class GrigoriClient
             }
 
             var result = await response.Content.ReadFromJsonAsync(JsonContext.Default.IndexFilesResponse);
-
-            onProgress?.Invoke(100);
 
             return result ?? new IndexFilesResponse(false, 0, 0, 0, "Empty response from server");
         }
@@ -71,3 +141,21 @@ public class GrigoriClient
         }
     }
 }
+
+public enum BatchStatus
+{
+    Uploading,
+    Completed,
+    Failed
+}
+
+public record BatchProgress(
+    int CurrentBatch,
+    int TotalBatches,
+    int FilesInBatch,
+    int TotalFiles,
+    BatchStatus Status,
+    int FilesIndexed = 0,
+    int ChunksCreated = 0,
+    string? Error = null
+);

--- a/src/Grigori.Cli/Program.cs
+++ b/src/Grigori.Cli/Program.cs
@@ -12,6 +12,7 @@ const string Dim = "\x1b[90m";
 var server = "http://localhost:5151";
 var path = ".";
 var showHelp = false;
+var batchSize = 100;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -21,6 +22,11 @@ for (int i = 0; i < args.Length; i++)
         case "--server":
             if (i + 1 < args.Length)
                 server = args[++i];
+            break;
+        case "-b":
+        case "--batch-size":
+            if (i + 1 < args.Length && int.TryParse(args[++i], out var size))
+                batchSize = size;
             break;
         case "-h":
         case "--help":
@@ -55,12 +61,14 @@ if (showHelp || args.Length == 0)
 
         {Yellow}Options:{Reset}
           -s, --server <url>    Grigori server URL (default: http://localhost:5151)
+          -b, --batch-size <n>  Files per batch (default: 100)
           -h, --help            Show help information
 
         {Yellow}Examples:{Reset}
           grigori index                     Index current directory
           grigori index ./my-project        Index specific directory
           grigori index . -s http://grigori:5151   Use custom server
+          grigori index . -b 50             Use smaller batch size
         """);
     return 0;
 }
@@ -105,17 +113,39 @@ if (files.Count == 0)
     return 0;
 }
 
-// Send to server
-Console.Write($"{Dim}Indexing...{Reset}");
-var result = await client.IndexFilesAsync(projectName, files);
+// Calculate number of batches
+var totalBatches = (int)Math.Ceiling(files.Count / (double)batchSize);
+Console.WriteLine($"{Dim}Uploading in {totalBatches} batch(es) of up to {batchSize} files each{Reset}");
+Console.WriteLine();
+
+// Send to server in batches
+var lastBatch = 0;
+var result = await client.IndexFilesInBatchesAsync(projectName, files, batchSize, progress =>
+{
+    if (progress.Status == BatchStatus.Uploading)
+    {
+        Console.Write($"\r{Dim}Batch {progress.CurrentBatch}/{progress.TotalBatches}:{Reset} Uploading {progress.FilesInBatch} files...          ");
+    }
+    else if (progress.Status == BatchStatus.Completed)
+    {
+        Console.WriteLine($"\r{Green}Batch {progress.CurrentBatch}/{progress.TotalBatches}:{Reset} {progress.FilesIndexed} files, {progress.ChunksCreated} chunks          ");
+        lastBatch = progress.CurrentBatch;
+    }
+    else if (progress.Status == BatchStatus.Failed)
+    {
+        Console.WriteLine($"\r{Red}Batch {progress.CurrentBatch}/{progress.TotalBatches}:{Reset} Failed - {progress.Error}          ");
+    }
+});
+
+Console.WriteLine();
 
 if (result.Success)
 {
-    Console.WriteLine($"\r{Green}Success!{Reset} Indexed {result.FilesIndexed} files with {result.ChunksCreated} chunks in {result.DurationMs}ms");
+    Console.WriteLine($"{Green}Success!{Reset} Indexed {result.FilesIndexed} files with {result.ChunksCreated} chunks in {result.DurationMs}ms");
     return 0;
 }
 else
 {
-    Console.WriteLine($"\r{Red}Error:{Reset} {result.Error}");
+    Console.WriteLine($"{Red}Error:{Reset} {result.Error}");
     return 1;
 }


### PR DESCRIPTION
## Summary
- Add `IndexFilesInBatchesAsync` method for batch uploads (default 100 files per batch)
- Add `BatchProgress` callback for real-time progress updates during indexing
- Add `--batch-size` (`-b`) CLI option to configure batch size

Closes #26

## Test plan
- [x] Build the solution
- [x] Test indexing small project (< 100 files)
- [x] Test indexing with custom batch size (`-b 50`)
- [x] Verify progress display shows batch status

🤖 Generated with [Claude Code](https://claude.com/claude-code)