### PR TITLE
fix: Search results show stale code content after new search

### DIFF
--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Search.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Search.razor
@@ -103,7 +103,7 @@
         <MudStack Spacing="3">
             @foreach (var result in _filteredResults)
             {
-                <MudCard Elevation="2">
+                <MudCard Elevation="2" @key="@($"{result.FilePath}:{result.StartLine}")">
                     <MudCardHeader Class="pb-0">
                         <CardHeaderAvatar>
                             <MudAvatar Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Small">


### PR DESCRIPTION
## Summary
- Add `@key` directive to search result cards to force Blazor to recreate elements when results change
- Prevents stale code content from being displayed after performing a new search

Closes #29

## Root Cause
Blazor's DOM diffing algorithm was reusing existing card elements. Without a `@key` directive, the inner content (especially the `<pre><code>` block) wasn't being properly updated when search results changed.

## Test plan
- [x] Build the solution
- [ ] Search for "authentication" 
- [ ] Search for a different term (e.g., "database")
- [ ] Verify code content updates to match new results

🤖 Generated with [Claude Code](https://claude.com/claude-code)