### PR TITLE
feat: Enable HNSW index for main search API

### DIFF
--- a/src/Grigori.Contracts/Interfaces/IChunkRepository.cs
+++ b/src/Grigori.Contracts/Interfaces/IChunkRepository.cs
@@ -30,6 +30,13 @@ public interface IChunkRepository
         string filePath,
         string hash,
         CancellationToken cancellationToken = default);
+
+    Task<Result<List<SearchResultItem>, GrigoriError>> GetChunksByIdsAsync(
+        IReadOnlyList<long> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<(long Id, float[] Embedding)>> GetAllEmbeddingsAsync(
+        CancellationToken cancellationToken = default);
 }
 
 public record CodeChunkInput

--- a/src/Grigori.DataAccess/Repositories/ChunkRepository.cs
+++ b/src/Grigori.DataAccess/Repositories/ChunkRepository.cs
@@ -147,6 +147,47 @@ public class ChunkRepository : IChunkRepository
         return await _dbContext.HasContentHashAsync(filePath, hash, cancellationToken);
     }
 
+    public async Task<Result<List<SearchResultItem>, GrigoriError>> GetChunksByIdsAsync(
+        IReadOnlyList<long> ids,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+        {
+            return new List<SearchResultItem>();
+        }
+
+        try
+        {
+            var chunks = await _dbContext.GetChunksByIdsAsync(ids, cancellationToken);
+
+            var results = chunks.Select(chunk => new SearchResultItem
+            {
+                Id = chunk.Id,
+                FilePath = chunk.FilePath,
+                StartLine = chunk.StartLine,
+                EndLine = chunk.EndLine,
+                Content = chunk.Content,
+                Score = 0f, // Score will be set by caller based on HNSW distance
+                Features = chunk.Features?.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList() ?? []
+            }).ToList();
+
+            return results;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get chunks by IDs");
+            return GrigoriError.DatabaseError($"Failed to get chunks by IDs: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<IEnumerable<(long Id, float[] Embedding)>> GetAllEmbeddingsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var chunks = await _dbContext.GetAllChunksAsync(cancellationToken);
+
+        return chunks.Select(chunk => (chunk.Id, DeserializeEmbedding(chunk.Embedding)));
+    }
+
     private byte[] SerializeEmbedding(float[] embedding)
     {
         if (_options.Quantization == QuantizationMode.Int8)

--- a/src/Grigori.Database/GrigoriDbContext.cs
+++ b/src/Grigori.Database/GrigoriDbContext.cs
@@ -173,6 +173,33 @@ public class GrigoriDbContext : IDisposable, IAsyncDisposable
         return chunks;
     }
 
+    public async Task<List<CodeChunk>> GetChunksByIdsAsync(IReadOnlyList<long> ids, CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+
+        var chunks = new List<CodeChunk>();
+
+        await using var cmd = _connection.CreateCommand();
+        var idParams = string.Join(",", ids.Select((_, i) => $"@id{i}"));
+        cmd.CommandText = $"SELECT id, file_path, start_line, end_line, content, content_hash, embedding, features, indexed_at FROM chunks WHERE id IN ({idParams})";
+
+        for (var i = 0; i < ids.Count; i++)
+        {
+            cmd.Parameters.AddWithValue($"@id{i}", ids[i]);
+        }
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            chunks.Add(ReadChunk(reader));
+        }
+
+        return chunks;
+    }
+
     public async Task<List<CodeChunk>> SearchChunksAsync(
         List<string>? fileExtensions = null,
         List<string>? requiredFeatures = null,

--- a/src/Grigori.Mcp/Features/Index/Services/IndexService.cs
+++ b/src/Grigori.Mcp/Features/Index/Services/IndexService.cs
@@ -5,6 +5,7 @@ using Grigori.Contracts.Options;
 using Grigori.Contracts.Results;
 using Grigori.Database;
 using Grigori.Infrastructure.Chunking;
+using Grigori.Infrastructure.Indexing;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -17,6 +18,7 @@ public class IndexService : IIndexService
     private readonly IEmbeddingProvider _embeddingProvider;
     private readonly IMetricsService _metricsService;
     private readonly ChunkingService _chunkingService;
+    private readonly HnswIndex _hnswIndex;
     private readonly GrigoriOptions _options;
     private readonly ILogger<IndexService> _logger;
 
@@ -25,6 +27,7 @@ public class IndexService : IIndexService
         IEmbeddingProvider embeddingProvider,
         IMetricsService metricsService,
         ChunkingService chunkingService,
+        HnswIndex hnswIndex,
         IOptions<GrigoriOptions> options,
         ILogger<IndexService> logger)
     {
@@ -32,6 +35,7 @@ public class IndexService : IIndexService
         _embeddingProvider = embeddingProvider;
         _metricsService = metricsService;
         _chunkingService = chunkingService;
+        _hnswIndex = hnswIndex;
         _options = options.Value;
         _logger = logger;
     }
@@ -110,6 +114,12 @@ public class IndexService : IIndexService
             if (totalFilesIndexed > 0)
             {
                 await _metricsService.RecordIndexingAsync(request.Path, stopwatch.ElapsedMilliseconds, totalFilesIndexed, totalChunksIndexed, cancellationToken);
+
+                // Rebuild HNSW index if enabled
+                if (_options.Hnsw.Enabled)
+                {
+                    await RebuildHnswIndexAsync(cancellationToken);
+                }
             }
 
             return new IndexResultDto
@@ -149,6 +159,12 @@ public class IndexService : IIndexService
 
             stopwatch.Stop();
             await _metricsService.RecordIndexingAsync(filePath, stopwatch.ElapsedMilliseconds, 1, chunkCount.Value, cancellationToken);
+
+            // Rebuild HNSW index if enabled
+            if (_options.Hnsw.Enabled && chunkCount.Value > 0)
+            {
+                await RebuildHnswIndexAsync(cancellationToken);
+            }
 
             return new IndexResultDto
             {
@@ -227,5 +243,31 @@ public class IndexService : IIndexService
     {
         var extension = Path.GetExtension(path).ToLowerInvariant();
         return _options.FileExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task RebuildHnswIndexAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var embeddings = await _chunkRepository.GetAllEmbeddingsAsync(cancellationToken);
+            var embeddingList = embeddings.ToList();
+
+            if (embeddingList.Count == 0)
+            {
+                _logger.LogDebug("No embeddings found, skipping HNSW index rebuild");
+                return;
+            }
+
+            _hnswIndex.BuildIndex(embeddingList);
+            stopwatch.Stop();
+
+            _logger.LogInformation("Rebuilt HNSW index with {Count} vectors in {ElapsedMs}ms",
+                embeddingList.Count, stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rebuild HNSW index");
+        }
     }
 }

--- a/src/Grigori.Mcp/Features/Search/Services/SearchService.cs
+++ b/src/Grigori.Mcp/Features/Search/Services/SearchService.cs
@@ -3,9 +3,12 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Grigori.Contracts.Dtos.Search;
 using Grigori.Contracts.Interfaces;
+using Grigori.Contracts.Options;
 using Grigori.Contracts.Results;
 using Grigori.Infrastructure.Chunking;
+using Grigori.Infrastructure.Indexing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Grigori.Mcp.Features.Search.Services;
 
@@ -14,6 +17,8 @@ public class SearchService : ISearchService
     private readonly IChunkRepository _chunkRepository;
     private readonly IEmbeddingProvider _embeddingProvider;
     private readonly IMetricsService _metricsService;
+    private readonly HnswIndex _hnswIndex;
+    private readonly GrigoriOptions _options;
     private readonly ILogger<SearchService> _logger;
 
     private const float DefaultScoreThreshold = 0.3f;
@@ -25,11 +30,15 @@ public class SearchService : ISearchService
         IChunkRepository chunkRepository,
         IEmbeddingProvider embeddingProvider,
         IMetricsService metricsService,
+        HnswIndex hnswIndex,
+        IOptions<GrigoriOptions> options,
         ILogger<SearchService> logger)
     {
         _chunkRepository = chunkRepository;
         _embeddingProvider = embeddingProvider;
         _metricsService = metricsService;
+        _hnswIndex = hnswIndex;
+        _options = options.Value;
         _logger = logger;
     }
 
@@ -68,21 +77,65 @@ public class SearchService : ISearchService
                     .ToList();
             }
 
-            // Search repository
-            var searchResult = await _chunkRepository.SearchAsync(
-                queryEmbedding,
-                request.Limit * 2,
-                DefaultScoreThreshold,
-                requiredFeatures: null,
-                fileExtensions: fileExtensions,
-                cancellationToken);
+            // Try HNSW search first if enabled and index is built
+            var usedHnsw = false;
+            List<SearchResultItem> results;
 
-            if (searchResult.IsFailure)
+            if (_options.Hnsw.Enabled && _hnswIndex.IsBuilt && fileExtensions == null)
             {
-                return searchResult.Error;
-            }
+                // Use HNSW for approximate nearest neighbor search
+                var hnswResults = _hnswIndex.Search(queryEmbedding, request.Limit * 2);
 
-            var results = searchResult.Value;
+                if (hnswResults.Count > 0)
+                {
+                    usedHnsw = true;
+                    var candidateIds = hnswResults
+                        .Where(r => HnswIndex.DistanceToSimilarity(r.Distance) >= DefaultScoreThreshold)
+                        .Select(r => r.Id)
+                        .ToList();
+
+                    var chunksResult = await _chunkRepository.GetChunksByIdsAsync(candidateIds, cancellationToken);
+                    if (chunksResult.IsFailure)
+                    {
+                        return chunksResult.Error;
+                    }
+
+                    // Create a lookup for HNSW distances
+                    var distanceLookup = hnswResults.ToDictionary(r => r.Id, r => r.Distance);
+
+                    // Set scores from HNSW distances
+                    results = chunksResult.Value.Select(r => r with
+                    {
+                        Score = distanceLookup.TryGetValue(r.Id, out var distance)
+                            ? HnswIndex.DistanceToSimilarity(distance)
+                            : r.Score
+                    }).ToList();
+
+                    _logger.LogDebug("HNSW search returned {Count} results", results.Count);
+                }
+                else
+                {
+                    results = [];
+                }
+            }
+            else
+            {
+                // Fall back to linear scan (required when filtering by file extensions)
+                var searchResult = await _chunkRepository.SearchAsync(
+                    queryEmbedding,
+                    request.Limit * 2,
+                    DefaultScoreThreshold,
+                    requiredFeatures: null,
+                    fileExtensions: fileExtensions,
+                    cancellationToken);
+
+                if (searchResult.IsFailure)
+                {
+                    return searchResult.Error;
+                }
+
+                results = searchResult.Value;
+            }
 
             // Apply feature boosting
             if (queryFeatures.Count > 0)
@@ -97,7 +150,7 @@ public class SearchService : ISearchService
                 .ToList();
 
             stopwatch.Stop();
-            await _metricsService.RecordSearchAsync(request.Query, stopwatch.ElapsedMilliseconds, finalResults.Count, cacheHit, false, cancellationToken);
+            await _metricsService.RecordSearchAsync(request.Query, stopwatch.ElapsedMilliseconds, finalResults.Count, cacheHit, usedHnsw, cancellationToken);
 
             // Format results based on output mode
             var formattedResults = FormatResults(finalResults, request.OutputMode);


### PR DESCRIPTION
## Summary
- Integrates HNSW (Hierarchical Navigable Small World) index into the main search API for faster approximate nearest neighbor search
- Adds repository methods to fetch chunks by IDs and retrieve all embeddings for HNSW rebuild
- Automatically rebuilds HNSW index after indexing operations
- Updates metrics to correctly record HNSW usage

## Changes
- **IChunkRepository**: Added `GetChunksByIdsAsync` and `GetAllEmbeddingsAsync` methods
- **ChunkRepository**: Implemented new repository methods
- **GrigoriDbContext**: Added `GetChunksByIdsAsync` database method
- **SearchService**: Injected `HnswIndex`, uses HNSW when enabled and built, falls back to linear scan for file extension filtering
- **IndexService**: Injected `HnswIndex`, rebuilds index after indexing operations

## Test plan
- [ ] Verify build compiles successfully
- [ ] Index a directory and confirm HNSW index is built (check logs)
- [ ] Run a search and verify HNSW is used (check metrics)
- [ ] Run a search with file type filter and verify fallback to linear scan
- [ ] Verify metrics correctly show HNSW usage

Closes #37