### PR TITLE
feat: Add hybrid search support to Dashboard search bar

### DIFF
--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Search.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Search.razor
@@ -2,21 +2,49 @@
 
 <PageTitle>Search - Grigori</PageTitle>
 
-<MudText Typo="Typo.h4" Class="mb-4">Semantic Search</MudText>
+<MudText Typo="Typo.h4" Class="mb-4">Code Search</MudText>
 
 @* Search Input *@
 <MudPaper Elevation="1" Class="pa-4 mb-4">
-    <MudTextField T="string"
-                  Value="_query"
-                  ValueChanged="OnQueryChanged"
-                  Placeholder="Search code semantically... (e.g., 'function that handles user authentication')"
-                  Variant="Variant.Outlined"
-                  Adornment="Adornment.Start"
-                  AdornmentIcon="@Icons.Material.Filled.Search"
-                  Immediate="true"
-                  OnKeyDown="HandleKeyDown"
-                  FullWidth="true"
-                  Clearable="true" />
+    <MudStack Spacing="3">
+        <MudTextField T="string"
+                      Value="_query"
+                      ValueChanged="OnQueryChanged"
+                      Placeholder="@GetSearchPlaceholder()"
+                      Variant="Variant.Outlined"
+                      Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search"
+                      Immediate="true"
+                      OnKeyDown="HandleKeyDown"
+                      FullWidth="true"
+                      Clearable="true" />
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">Search Mode:</MudText>
+            <MudToggleGroup T="string" Value="_searchMode" ValueChanged="OnSearchModeChanged" Size="Size.Small" Color="Color.Primary">
+                <MudToggleItem Value="@("hybrid")">
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.AutoAwesome" Size="Size.Small" />
+                        <MudText Typo="Typo.body2">Hybrid</MudText>
+                    </MudStack>
+                </MudToggleItem>
+                <MudToggleItem Value="@("semantic")">
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.Psychology" Size="Size.Small" />
+                        <MudText Typo="Typo.body2">Semantic</MudText>
+                    </MudStack>
+                </MudToggleItem>
+                <MudToggleItem Value="@("lexical")">
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                        <MudIcon Icon="@Icons.Material.Filled.TextFields" Size="Size.Small" />
+                        <MudText Typo="Typo.body2">Lexical</MudText>
+                    </MudStack>
+                </MudToggleItem>
+            </MudToggleGroup>
+            <MudTooltip Text="@GetSearchModeTooltip()">
+                <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Style="color: var(--mud-palette-text-secondary); cursor: help;" />
+            </MudTooltip>
+        </MudStack>
+    </MudStack>
 </MudPaper>
 
 @* Filters *@
@@ -72,6 +100,9 @@
 
             <MudSpacer />
 
+            <MudChip T="string" Icon="@GetSearchModeIcon()" Size="Size.Small" Variant="Variant.Text" Color="Color.Secondary">
+                @_searchMode
+            </MudChip>
             <MudChip T="string" Icon="@Icons.Material.Filled.Timer" Size="Size.Small" Variant="Variant.Text">
                 @_searchDuration.TotalMilliseconds.ToString("F0")ms
             </MudChip>

--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Search.razor.cs
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Search.razor.cs
@@ -2,6 +2,7 @@ using Grigori.Mcp.Dashboard.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using MudBlazor;
 
 namespace Grigori.Mcp.Dashboard.Components.Pages;
 
@@ -11,6 +12,7 @@ public partial class Search : ComponentBase, IAsyncDisposable
     [Inject] private IJSRuntime JS { get; set; } = default!;
 
     private string _query = string.Empty;
+    private string _searchMode = "hybrid";
     private string? _selectedFileType;
     private string? _selectedProject;
     private List<SearchResult>? _results;
@@ -79,7 +81,7 @@ public partial class Search : ComponentBase, IAsyncDisposable
         try
         {
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            _results = await DashboardService.SearchAsync(_query, 50); // Get more results for filtering
+            _results = await DashboardService.SearchAsync(_query, 50, _searchMode); // Get more results for filtering
             sw.Stop();
             _searchDuration = sw.Elapsed;
 
@@ -102,6 +104,15 @@ public partial class Search : ComponentBase, IAsyncDisposable
         }
     }
 
+    private async Task OnSearchModeChanged(string value)
+    {
+        _searchMode = value;
+        if (!string.IsNullOrWhiteSpace(_query))
+        {
+            await RunSearchAsync();
+        }
+    }
+
     private void OnFileTypeChanged(string? value)
     {
         _selectedFileType = value;
@@ -113,6 +124,27 @@ public partial class Search : ComponentBase, IAsyncDisposable
         _selectedProject = value;
         ApplyFilters();
     }
+
+    private string GetSearchPlaceholder() => _searchMode switch
+    {
+        "semantic" => "Search code semantically... (e.g., 'function that handles user authentication')",
+        "lexical" => "Search for exact keywords... (e.g., 'getUserById')",
+        _ => "Search code... (combines semantic understanding with keyword matching)"
+    };
+
+    private string GetSearchModeTooltip() => _searchMode switch
+    {
+        "semantic" => "Semantic search uses AI embeddings to find conceptually similar code, even with different wording.",
+        "lexical" => "Lexical search (BM25) finds exact keyword matches, great for function names and identifiers.",
+        _ => "Hybrid search combines semantic and lexical results using Reciprocal Rank Fusion for best results."
+    };
+
+    private string GetSearchModeIcon() => _searchMode switch
+    {
+        "semantic" => Icons.Material.Filled.Psychology,
+        "lexical" => Icons.Material.Filled.TextFields,
+        _ => Icons.Material.Filled.AutoAwesome
+    };
 
     private void ApplyFilters()
     {

--- a/src/Grigori.Mcp/Dashboard/Services/DashboardService.cs
+++ b/src/Grigori.Mcp/Dashboard/Services/DashboardService.cs
@@ -1,4 +1,5 @@
 using Grigori.Contracts.Dtos.Metrics;
+using Grigori.Contracts.Dtos.Search;
 using Grigori.Contracts.Interfaces;
 using Grigori.Database;
 using Grigori.Infrastructure.Indexing;
@@ -12,10 +13,10 @@ public class DashboardService
     private readonly HnswIndex _hnswIndex;
     private readonly IServiceProvider _serviceProvider;
 
-    // Lazy-load embedding provider to avoid blocking page render
-    private IEmbeddingProvider? _embeddingProvider;
-    private IEmbeddingProvider EmbeddingProvider =>
-        _embeddingProvider ??= _serviceProvider.GetRequiredService<IEmbeddingProvider>();
+    // Lazy-load services to avoid blocking page render
+    private ISearchService? _searchService;
+    private ISearchService SearchService =>
+        _searchService ??= _serviceProvider.GetRequiredService<ISearchService>();
 
     public DashboardService(
         GrigoriDbContext dbContext,
@@ -118,110 +119,33 @@ public class DashboardService
         return bestMatch ?? filePath;
     }
 
-    public async Task<List<SearchResult>> SearchAsync(string query, int limit = 10)
+    public async Task<List<SearchResult>> SearchAsync(string query, int limit = 10, string searchMode = "hybrid")
     {
         if (string.IsNullOrWhiteSpace(query))
             return [];
 
-        // Generate embedding for query (lazy-loads embedding provider on first search)
-        var embeddingResult = await EmbeddingProvider.GetEmbeddingAsync(
-            query,
-            EmbeddingInputType.Query);
+        // Use the shared SearchService for consistent search behavior
+        var request = new SearchRequestDto
+        {
+            Query = query,
+            Limit = limit,
+            SearchMode = searchMode,
+            OutputMode = "full"
+        };
 
-        if (embeddingResult.IsFailure)
+        var result = await SearchService.SearchAsync(request);
+
+        if (result.IsFailure)
             return [];
 
-        var queryEmbedding = embeddingResult.Value;
-
-        // Search using HNSW if available
-        if (_hnswIndex.IsBuilt)
+        return result.Value.Results.Select(r => new SearchResult
         {
-            var searchResults = _hnswIndex.Search(queryEmbedding, limit);
-
-            // Fetch chunk details
-            var chunks = await _dbContext.GetAllChunksAsync();
-            var chunkDict = chunks.ToDictionary(c => c.Id);
-
-            return searchResults
-                .Where(r => chunkDict.ContainsKey(r.Id))
-                .Select(r =>
-                {
-                    var chunk = chunkDict[r.Id];
-                    return new SearchResult
-                    {
-                        FilePath = chunk.FilePath,
-                        StartLine = chunk.StartLine,
-                        EndLine = chunk.EndLine,
-                        Content = chunk.Content,
-                        Score = HnswIndex.DistanceToSimilarity(r.Distance)
-                    };
-                })
-                .ToList();
-        }
-
-        // Fallback to linear scan
-        var allChunks = await _dbContext.GetAllChunksAsync();
-        return allChunks
-            .Select(c => new
-            {
-                Chunk = c,
-                Embedding = DeserializeEmbedding(c.Embedding)
-            })
-            .Select(x => new SearchResult
-            {
-                FilePath = x.Chunk.FilePath,
-                StartLine = x.Chunk.StartLine,
-                EndLine = x.Chunk.EndLine,
-                Content = x.Chunk.Content,
-                Score = CosineSimilarity(queryEmbedding, x.Embedding)
-            })
-            .OrderByDescending(r => r.Score)
-            .Take(limit)
-            .ToList();
-    }
-
-    private static float[] DeserializeEmbedding(byte[] bytes)
-    {
-        // Detect format - common dimensions for float32
-        int[] commonDimensions = [384, 768, 1024, 1536];
-        var floatCount = bytes.Length / sizeof(float);
-
-        if (Array.Exists(commonDimensions, d => d == floatCount))
-        {
-            // Float32 format
-            var embedding = new float[floatCount];
-            Buffer.BlockCopy(bytes, 0, embedding, 0, bytes.Length);
-            return embedding;
-        }
-
-        // Int8 quantized format
-        var scale = BitConverter.ToSingle(bytes, 0);
-        var zeroPoint = BitConverter.ToSingle(bytes, 4);
-        var result = new float[bytes.Length - 8];
-
-        for (var i = 0; i < result.Length; i++)
-        {
-            result[i] = (bytes[8 + i] - zeroPoint) * scale;
-        }
-
-        return result;
-    }
-
-    private static float CosineSimilarity(float[] a, float[] b)
-    {
-        if (a.Length != b.Length)
-            return 0f;
-
-        float dot = 0, normA = 0, normB = 0;
-        for (int i = 0; i < a.Length; i++)
-        {
-            dot += a[i] * b[i];
-            normA += a[i] * a[i];
-            normB += b[i] * b[i];
-        }
-
-        var denom = MathF.Sqrt(normA) * MathF.Sqrt(normB);
-        return denom > 0 ? dot / denom : 0f;
+            FilePath = r.FilePath,
+            StartLine = r.StartLine,
+            EndLine = r.EndLine,
+            Content = r.Content,
+            Score = r.Score
+        }).ToList();
     }
 
     public async Task<List<ActivityLogDto>> GetRecentActivityAsync(int limit = 20)


### PR DESCRIPTION
## Summary
- Adds search mode selector (Hybrid/Semantic/Lexical) to the Dashboard search page
- Updates DashboardService to delegate to ISearchService for consistent search behavior
- Removes duplicate HNSW/linear scan code from DashboardService
- Adds dynamic placeholders and tooltips that explain each search mode

## Changes
- **Search.razor**: Added MudToggleGroup for search mode selection with icons
- **Search.razor.cs**: Added search mode state, helper methods for placeholders/tooltips/icons
- **DashboardService.cs**: Simplified SearchAsync to use ISearchService instead of direct DB/HNSW access

## Screenshots
The search page now shows:
- Toggle buttons for Hybrid (default), Semantic, and Lexical search modes
- Info tooltip explaining each mode
- Search mode chip in the filter bar

## Test plan
- [ ] Verify build compiles successfully
- [ ] Test search with each mode (hybrid, semantic, lexical)
- [ ] Verify search results are consistent with MCP API search
- [ ] Test mode switching re-runs search with current query

Closes #40