### PR TITLE
test: Add hybrid search tests for single-method matching

### DIFF
--- a/Grigori.slnx
+++ b/Grigori.slnx
@@ -7,4 +7,7 @@
     <Project Path="src/Grigori.Mcp/Grigori.Mcp.csproj" />
     <Project Path="src/Grigori.Cli/Grigori.Cli.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Grigori.Tests/Grigori.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/tests/Grigori.Tests/Grigori.Tests.csproj
+++ b/tests/Grigori.Tests/Grigori.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Grigori.Mcp\Grigori.Mcp.csproj" />
+    <ProjectReference Include="..\..\src\Grigori.Contracts\Grigori.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Grigori.Tests/HybridSearchTests.cs
+++ b/tests/Grigori.Tests/HybridSearchTests.cs
@@ -1,0 +1,307 @@
+using Grigori.Contracts.Dtos.Metrics;
+using Grigori.Contracts.Dtos.Search;
+using Grigori.Contracts.Interfaces;
+using Grigori.Contracts.Options;
+using Grigori.Contracts.Results;
+using Grigori.Infrastructure.Indexing;
+using Grigori.Mcp.Features.Search.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Grigori.Tests;
+
+/// <summary>
+/// Tests for hybrid search to verify it returns results when only one
+/// search method (semantic or lexical) finds matches.
+/// </summary>
+public class HybridSearchTests
+{
+    private readonly Mock<IChunkRepository> _mockChunkRepository;
+    private readonly Mock<IEmbeddingProvider> _mockEmbeddingProvider;
+    private readonly Mock<IMetricsService> _mockMetricsService;
+    private readonly HnswIndex _hnswIndex;
+    private readonly IOptions<GrigoriOptions> _options;
+    private readonly SearchService _searchService;
+
+    public HybridSearchTests()
+    {
+        _mockChunkRepository = new Mock<IChunkRepository>();
+        _mockEmbeddingProvider = new Mock<IEmbeddingProvider>();
+        _mockMetricsService = new Mock<IMetricsService>();
+
+        // Create a real HnswIndex but with HNSW disabled via options
+        _hnswIndex = new HnswIndex(NullLogger<HnswIndex>.Instance);
+
+        // Disable HNSW so tests use the repository path
+        _options = Options.Create(new GrigoriOptions
+        {
+            Hnsw = new HnswOptions { Enabled = false }
+        });
+
+        // Setup default metrics mock
+        _mockMetricsService
+            .Setup(m => m.RecordSearchAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockMetricsService
+            .Setup(m => m.RecordEmbeddingGeneration(It.IsAny<long>(), It.IsAny<int>()));
+
+        _searchService = new SearchService(
+            _mockChunkRepository.Object,
+            _mockEmbeddingProvider.Object,
+            _mockMetricsService.Object,
+            _hnswIndex,
+            _options,
+            NullLogger<SearchService>.Instance);
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithOnlySemanticResults_ReturnsSemanticResults()
+    {
+        // Arrange
+        var query = "authentication logic";
+        var queryEmbedding = new float[] { 0.1f, 0.2f, 0.3f };
+
+        var semanticResults = new List<SearchResultItem>
+        {
+            new() { Id = 1, FilePath = "auth.cs", StartLine = 10, EndLine = 20, Content = "public class Auth {}", Score = 0.9f },
+            new() { Id = 2, FilePath = "login.cs", StartLine = 1, EndLine = 15, Content = "public void Login() {}", Score = 0.8f }
+        };
+
+        // Setup embedding provider to return valid embedding
+        _mockEmbeddingProvider
+            .Setup(e => e.GetEmbeddingAsync(query, EmbeddingInputType.Query, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<float[], GrigoriError>.Success(queryEmbedding));
+
+        // Setup repository to return semantic results
+        _mockChunkRepository
+            .Setup(r => r.SearchAsync(queryEmbedding, It.IsAny<int>(), It.IsAny<float>(), null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<SearchResultItem>, GrigoriError>.Success(semanticResults));
+
+        // Setup repository to return empty lexical results (no content matches BM25)
+        _mockChunkRepository
+            .Setup(r => r.GetChunksForLexicalSearchAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<ChunkForLexicalSearch>, GrigoriError>.Success(new List<ChunkForLexicalSearch>()));
+
+        // Act
+        var result = await _searchService.SearchAsync(new SearchRequestDto
+        {
+            Query = query,
+            Limit = 10,
+            SearchMode = "hybrid"
+        });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Count);
+        Assert.Equal("auth.cs", result.Value.Results[0].FilePath);
+        Assert.Equal("login.cs", result.Value.Results[1].FilePath);
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithOnlyLexicalResults_ReturnsLexicalResults()
+    {
+        // Arrange
+        var query = "XYZ_UNIQUE_KEYWORD_123"; // A query that won't have semantic meaning but exact match
+        var queryEmbedding = new float[] { 0.1f, 0.2f, 0.3f };
+
+        // Semantic search returns nothing (no semantic similarity)
+        var emptySemanticResults = new List<SearchResultItem>();
+
+        // Lexical search finds exact keyword matches
+        var lexicalChunks = new List<ChunkForLexicalSearch>
+        {
+            new() { Id = 10, FilePath = "config.cs", StartLine = 5, EndLine = 10, Content = "const string KEY = \"XYZ_UNIQUE_KEYWORD_123\";" },
+            new() { Id = 11, FilePath = "settings.cs", StartLine = 20, EndLine = 25, Content = "// XYZ_UNIQUE_KEYWORD_123 is used here" }
+        };
+
+        _mockEmbeddingProvider
+            .Setup(e => e.GetEmbeddingAsync(query, EmbeddingInputType.Query, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<float[], GrigoriError>.Success(queryEmbedding));
+
+        _mockChunkRepository
+            .Setup(r => r.SearchAsync(queryEmbedding, It.IsAny<int>(), It.IsAny<float>(), null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<SearchResultItem>, GrigoriError>.Success(emptySemanticResults));
+
+        _mockChunkRepository
+            .Setup(r => r.GetChunksForLexicalSearchAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<ChunkForLexicalSearch>, GrigoriError>.Success(lexicalChunks));
+
+        // Act
+        var result = await _searchService.SearchAsync(new SearchRequestDto
+        {
+            Query = query,
+            Limit = 10,
+            SearchMode = "hybrid"
+        });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Count);
+        // Results should be from lexical search
+        Assert.Contains(result.Value.Results, r => r.FilePath == "config.cs");
+        Assert.Contains(result.Value.Results, r => r.FilePath == "settings.cs");
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithBothResultsEmpty_ReturnsEmptyResults()
+    {
+        // Arrange
+        var query = "nonexistent gibberish query";
+        var queryEmbedding = new float[] { 0.1f, 0.2f, 0.3f };
+
+        _mockEmbeddingProvider
+            .Setup(e => e.GetEmbeddingAsync(query, EmbeddingInputType.Query, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<float[], GrigoriError>.Success(queryEmbedding));
+
+        _mockChunkRepository
+            .Setup(r => r.SearchAsync(queryEmbedding, It.IsAny<int>(), It.IsAny<float>(), null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<SearchResultItem>, GrigoriError>.Success(new List<SearchResultItem>()));
+
+        _mockChunkRepository
+            .Setup(r => r.GetChunksForLexicalSearchAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<ChunkForLexicalSearch>, GrigoriError>.Success(new List<ChunkForLexicalSearch>()));
+
+        // Act
+        var result = await _searchService.SearchAsync(new SearchRequestDto
+        {
+            Query = query,
+            Limit = 10,
+            SearchMode = "hybrid"
+        });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Value.Count);
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithBothResultsPresent_FusesAndReturnsResults()
+    {
+        // Arrange
+        var query = "database connection";
+        var queryEmbedding = new float[] { 0.1f, 0.2f, 0.3f };
+
+        // Semantic results
+        var semanticResults = new List<SearchResultItem>
+        {
+            new() { Id = 1, FilePath = "db.cs", StartLine = 1, EndLine = 10, Content = "class DbConnection {}", Score = 0.95f },
+            new() { Id = 2, FilePath = "repo.cs", StartLine = 5, EndLine = 15, Content = "void Connect() {}", Score = 0.85f }
+        };
+
+        // Lexical results - note Id=1 appears in both
+        var lexicalChunks = new List<ChunkForLexicalSearch>
+        {
+            new() { Id = 1, FilePath = "db.cs", StartLine = 1, EndLine = 10, Content = "class DbConnection { // database connection }" },
+            new() { Id = 3, FilePath = "config.cs", StartLine = 20, EndLine = 30, Content = "connectionString = \"database connection\"" }
+        };
+
+        _mockEmbeddingProvider
+            .Setup(e => e.GetEmbeddingAsync(query, EmbeddingInputType.Query, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<float[], GrigoriError>.Success(queryEmbedding));
+
+        _mockChunkRepository
+            .Setup(r => r.SearchAsync(queryEmbedding, It.IsAny<int>(), It.IsAny<float>(), null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<SearchResultItem>, GrigoriError>.Success(semanticResults));
+
+        _mockChunkRepository
+            .Setup(r => r.GetChunksForLexicalSearchAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<ChunkForLexicalSearch>, GrigoriError>.Success(lexicalChunks));
+
+        // Act
+        var result = await _searchService.SearchAsync(new SearchRequestDto
+        {
+            Query = query,
+            Limit = 10,
+            SearchMode = "hybrid"
+        });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value.Count >= 2); // At least the unique items from both lists
+
+        // Item 1 (db.cs) should be ranked highly as it appears in both lists
+        var dbResult = result.Value.Results.FirstOrDefault(r => r.FilePath == "db.cs");
+        Assert.NotNull(dbResult);
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithSemanticFailure_StillReturnsLexicalResults()
+    {
+        // Arrange
+        var query = "error handling";
+        var queryEmbedding = new float[] { 0.1f, 0.2f, 0.3f };
+
+        // Embedding provider fails
+        _mockEmbeddingProvider
+            .Setup(e => e.GetEmbeddingAsync(query, EmbeddingInputType.Query, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<float[], GrigoriError>.Success(queryEmbedding));
+
+        // Semantic search fails
+        _mockChunkRepository
+            .Setup(r => r.SearchAsync(queryEmbedding, It.IsAny<int>(), It.IsAny<float>(), null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GrigoriError.SearchFailed(query, "Semantic search failed"));
+
+        // Lexical search succeeds
+        var lexicalChunks = new List<ChunkForLexicalSearch>
+        {
+            new() { Id = 1, FilePath = "errors.cs", StartLine = 1, EndLine = 10, Content = "catch (Exception ex) { // error handling }" }
+        };
+        _mockChunkRepository
+            .Setup(r => r.GetChunksForLexicalSearchAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<ChunkForLexicalSearch>, GrigoriError>.Success(lexicalChunks));
+
+        // Act
+        var result = await _searchService.SearchAsync(new SearchRequestDto
+        {
+            Query = query,
+            Limit = 10,
+            SearchMode = "hybrid"
+        });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value.Count);
+        Assert.Equal("errors.cs", result.Value.Results[0].FilePath);
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithLexicalFailure_StillReturnsSemanticResults()
+    {
+        // Arrange
+        var query = "user authentication";
+        var queryEmbedding = new float[] { 0.1f, 0.2f, 0.3f };
+
+        var semanticResults = new List<SearchResultItem>
+        {
+            new() { Id = 1, FilePath = "auth.cs", StartLine = 1, EndLine = 20, Content = "public class Authentication {}", Score = 0.9f }
+        };
+
+        _mockEmbeddingProvider
+            .Setup(e => e.GetEmbeddingAsync(query, EmbeddingInputType.Query, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<float[], GrigoriError>.Success(queryEmbedding));
+
+        _mockChunkRepository
+            .Setup(r => r.SearchAsync(queryEmbedding, It.IsAny<int>(), It.IsAny<float>(), null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<SearchResultItem>, GrigoriError>.Success(semanticResults));
+
+        // Lexical search fails
+        _mockChunkRepository
+            .Setup(r => r.GetChunksForLexicalSearchAsync(null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GrigoriError.SearchFailed(query, "Lexical search failed"));
+
+        // Act
+        var result = await _searchService.SearchAsync(new SearchRequestDto
+        {
+            Query = query,
+            Limit = 10,
+            SearchMode = "hybrid"
+        });
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value.Count);
+        Assert.Equal("auth.cs", result.Value.Results[0].FilePath);
+    }
+}

--- a/tests/Grigori.Tests/ReciprocalRankFusionTests.cs
+++ b/tests/Grigori.Tests/ReciprocalRankFusionTests.cs
@@ -1,0 +1,270 @@
+using Grigori.Mcp.Features.Search.Services;
+
+namespace Grigori.Tests;
+
+/// <summary>
+/// Tests for ReciprocalRankFusion to verify it correctly handles edge cases
+/// where only one search method returns results.
+/// </summary>
+public class ReciprocalRankFusionTests
+{
+    [Fact]
+    public void Fuse_WithEmptyFirstList_ReturnsSecondListResults()
+    {
+        // Arrange
+        var emptyList = Array.Empty<int>();
+        var secondList = new[] { 1, 2, 3 };
+
+        // Act
+        var result = ReciprocalRankFusion.Fuse<int>([emptyList, secondList]);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(2, result[1].Id);
+        Assert.Equal(3, result[2].Id);
+    }
+
+    [Fact]
+    public void Fuse_WithEmptySecondList_ReturnsFirstListResults()
+    {
+        // Arrange
+        var firstList = new[] { 1, 2, 3 };
+        var emptyList = Array.Empty<int>();
+
+        // Act
+        var result = ReciprocalRankFusion.Fuse<int>([firstList, emptyList]);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(2, result[1].Id);
+        Assert.Equal(3, result[2].Id);
+    }
+
+    [Fact]
+    public void Fuse_WithBothListsEmpty_ReturnsEmptyResult()
+    {
+        // Arrange
+        var emptyList1 = Array.Empty<int>();
+        var emptyList2 = Array.Empty<int>();
+
+        // Act
+        var result = ReciprocalRankFusion.Fuse<int>([emptyList1, emptyList2]);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FuseWeighted_WithEmptyFirstList_ReturnsSecondListResults()
+    {
+        // Arrange
+        var emptyList = Array.Empty<int>();
+        var secondList = new[] { 10, 20, 30 };
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWeighted(emptyList, secondList);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(10, result[0].Id);
+        Assert.Equal(20, result[1].Id);
+        Assert.Equal(30, result[2].Id);
+    }
+
+    [Fact]
+    public void FuseWeighted_WithEmptySecondList_ReturnsFirstListResults()
+    {
+        // Arrange
+        var firstList = new[] { 10, 20, 30 };
+        var emptyList = Array.Empty<int>();
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWeighted(firstList, emptyList);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(10, result[0].Id);
+        Assert.Equal(20, result[1].Id);
+        Assert.Equal(30, result[2].Id);
+    }
+
+    [Fact]
+    public void FuseWeighted_WithBothListsEmpty_ReturnsEmptyResult()
+    {
+        // Arrange
+        var emptyList1 = Array.Empty<int>();
+        var emptyList2 = Array.Empty<int>();
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWeighted(emptyList1, emptyList2);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FuseWithScores_WithEmptySemanticResults_ReturnsLexicalResults()
+    {
+        // Arrange
+        var semanticResults = Array.Empty<(int Id, float Score)>();
+        var lexicalResults = new[]
+        {
+            (Id: 1, Score: 0.9),
+            (Id: 2, Score: 0.7),
+            (Id: 3, Score: 0.5)
+        };
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWithScores(semanticResults, lexicalResults);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(2, result[1].Id);
+        Assert.Equal(3, result[2].Id);
+        // Verify these came only from lexical (not in both lists)
+        Assert.All(result, r => Assert.False(r.InBothLists));
+        Assert.All(result, r => Assert.Equal(0, r.SemanticScore));
+    }
+
+    [Fact]
+    public void FuseWithScores_WithEmptyLexicalResults_ReturnsSemanticResults()
+    {
+        // Arrange
+        var semanticResults = new[]
+        {
+            (Id: 1, Score: 0.95f),
+            (Id: 2, Score: 0.85f),
+            (Id: 3, Score: 0.75f)
+        };
+        var lexicalResults = Array.Empty<(int Id, double Score)>();
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWithScores(semanticResults, lexicalResults);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(2, result[1].Id);
+        Assert.Equal(3, result[2].Id);
+        // Verify these came only from semantic (not in both lists)
+        Assert.All(result, r => Assert.False(r.InBothLists));
+        Assert.All(result, r => Assert.Equal(0, r.LexicalScore));
+    }
+
+    [Fact]
+    public void FuseWithScores_WithBothListsEmpty_ReturnsEmptyResult()
+    {
+        // Arrange
+        var semanticResults = Array.Empty<(int Id, float Score)>();
+        var lexicalResults = Array.Empty<(int Id, double Score)>();
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWithScores(semanticResults, lexicalResults);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FuseWithScores_WithOverlappingResults_MarksAsInBothLists()
+    {
+        // Arrange
+        var semanticResults = new[]
+        {
+            (Id: 1, Score: 0.9f),
+            (Id: 2, Score: 0.8f)
+        };
+        var lexicalResults = new[]
+        {
+            (Id: 2, Score: 0.85),
+            (Id: 3, Score: 0.7)
+        };
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWithScores(semanticResults, lexicalResults);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+
+        var item2 = result.First(r => r.Id == 2);
+        Assert.True(item2.InBothLists);
+        Assert.Equal(0.8f, item2.SemanticScore);
+        Assert.Equal(0.85, item2.LexicalScore);
+
+        var item1 = result.First(r => r.Id == 1);
+        Assert.False(item1.InBothLists);
+        Assert.Equal(0.9f, item1.SemanticScore);
+        Assert.Equal(0, item1.LexicalScore);
+
+        var item3 = result.First(r => r.Id == 3);
+        Assert.False(item3.InBothLists);
+        Assert.Equal(0, item3.SemanticScore);
+        Assert.Equal(0.7, item3.LexicalScore);
+    }
+
+    [Fact]
+    public void FuseWithScores_ItemInBothLists_HasHigherFusedScore()
+    {
+        // Arrange - Item 2 appears in both lists
+        var semanticResults = new[]
+        {
+            (Id: 1, Score: 0.9f),
+            (Id: 2, Score: 0.8f)
+        };
+        var lexicalResults = new[]
+        {
+            (Id: 2, Score: 0.85),
+            (Id: 3, Score: 0.9)
+        };
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWithScores(semanticResults, lexicalResults);
+
+        // Assert - Item 2 should have highest fused score because it's in both lists
+        Assert.Equal(2, result[0].Id);
+        Assert.True(result[0].InBothLists);
+    }
+
+    [Fact]
+    public void Fuse_PreservesRankOrdering_FromSingleList()
+    {
+        // Arrange - only one list with specific ordering
+        var rankedList = new[] { 100, 200, 300, 400, 500 };
+        var emptyList = Array.Empty<int>();
+
+        // Act
+        var result = ReciprocalRankFusion.Fuse<int>([rankedList, emptyList]);
+
+        // Assert - order should be preserved
+        Assert.Equal(5, result.Count);
+        for (int i = 0; i < 5; i++)
+        {
+            Assert.Equal(rankedList[i], result[i].Id);
+        }
+    }
+
+    [Fact]
+    public void FuseWithScores_WithWeights_AppliesCorrectly()
+    {
+        // Arrange - same items in both lists, different weights
+        var semanticResults = new[] { (Id: 1, Score: 0.9f) };
+        var lexicalResults = new[] { (Id: 2, Score: 0.9) };
+        var semanticWeight = 2.0;
+        var lexicalWeight = 1.0;
+
+        // Act
+        var result = ReciprocalRankFusion.FuseWithScores(
+            semanticResults,
+            lexicalResults,
+            semanticWeight,
+            lexicalWeight);
+
+        // Assert - semantic result should have higher fused score due to weight
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].Id); // Semantic result first due to higher weight
+        Assert.True(result[0].FusedScore > result[1].FusedScore);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test project for the solution, focusing on comprehensive unit tests for the hybrid search and reciprocal rank fusion logic. The changes ensure the search functionality is robust, especially in edge cases where only one search method returns results or when results overlap.

**Test Infrastructure Setup:**

* Added a new test project `Grigori.Tests` to the solution, including its project file and references to necessary packages and source projects. [[1]](diffhunk://#diff-8c96194e9c530bed81f5a1a406a320c8fb3b75efe95eb7f3e4990e8095d5dfafR10-R12) [[2]](diffhunk://#diff-62ecc502ee62bd1765ed26243d3ff76e42e0f93f138872b41a37e4943019f188R1-R29)

**Hybrid Search Functionality Tests:**

* Implemented `HybridSearchTests` to verify the hybrid search returns correct results when only one of semantic or lexical search finds matches, both are empty, both return results (fusion), or when one search method fails.

**Reciprocal Rank Fusion Logic Tests:**

* Added `ReciprocalRankFusionTests` to thoroughly test the fusion logic, ensuring correct handling of empty lists, overlapping results, score weighting, and preservation of rank ordering.