### PR TITLE
feat(dashboard): Add GitHub PAT authentication integration

### DIFF
--- a/src/Grigori.Contracts/Dtos/GitHub/GitHubDtos.cs
+++ b/src/Grigori.Contracts/Dtos/GitHub/GitHubDtos.cs
@@ -1,0 +1,100 @@
+namespace Grigori.Contracts.Dtos.GitHub;
+
+/// <summary>
+/// Result of a GitHub authentication attempt.
+/// </summary>
+public record GitHubAuthResult(bool Success, string? ErrorMessage = null, GitHubUserDto? User = null)
+{
+    public static GitHubAuthResult Succeeded(GitHubUserDto user) => new(true, null, user);
+    public static GitHubAuthResult Failed(string error) => new(false, error);
+}
+
+/// <summary>
+/// GitHub user information.
+/// </summary>
+public record GitHubUserDto(
+    string Login,
+    string? Name,
+    string? AvatarUrl,
+    string? Email,
+    int PublicRepos,
+    int PrivateRepos,
+    DateTime CreatedAt
+);
+
+/// <summary>
+/// GitHub repository information.
+/// </summary>
+public record GitHubRepositoryDto(
+    long Id,
+    string Name,
+    string FullName,
+    string? Description,
+    string DefaultBranch,
+    bool IsPrivate,
+    string? Language,
+    int StarCount,
+    int ForkCount,
+    int OpenIssuesCount,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    DateTime? PushedAt,
+    string HtmlUrl,
+    string CloneUrl
+);
+
+/// <summary>
+/// GitHub commit information.
+/// </summary>
+public record GitHubCommitDto(
+    string Sha,
+    string ShortSha,
+    string Message,
+    string? AuthorName,
+    string? AuthorEmail,
+    string? AuthorAvatarUrl,
+    DateTime CommittedAt,
+    string HtmlUrl,
+    int Additions,
+    int Deletions,
+    int ChangedFiles
+)
+{
+    public string ShortMessage => Message.Length > 72
+        ? Message[..69] + "..."
+        : Message.Split('\n')[0];
+}
+
+/// <summary>
+/// GitHub pull request information.
+/// </summary>
+public record GitHubPullRequestDto(
+    int Number,
+    string Title,
+    string State,
+    string? Body,
+    string AuthorLogin,
+    string? AuthorAvatarUrl,
+    string HeadBranch,
+    string BaseBranch,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    DateTime? MergedAt,
+    DateTime? ClosedAt,
+    string HtmlUrl,
+    int Additions,
+    int Deletions,
+    int ChangedFiles,
+    int CommitCount,
+    bool IsDraft
+);
+
+/// <summary>
+/// GitHub branch information.
+/// </summary>
+public record GitHubBranchDto(
+    string Name,
+    string CommitSha,
+    bool IsProtected,
+    bool IsDefault
+);

--- a/src/Grigori.Contracts/Interfaces/IGitHubService.cs
+++ b/src/Grigori.Contracts/Interfaces/IGitHubService.cs
@@ -1,0 +1,66 @@
+using Grigori.Contracts.Dtos.GitHub;
+
+namespace Grigori.Contracts.Interfaces;
+
+/// <summary>
+/// Service for GitHub integration using Personal Access Token (PAT) authentication.
+/// All GitHub-dependent features should check IsAuthenticated before attempting operations.
+/// </summary>
+public interface IGitHubService
+{
+    /// <summary>
+    /// Gets whether a valid GitHub token is configured.
+    /// </summary>
+    bool IsAuthenticated { get; }
+
+    /// <summary>
+    /// Event raised when authentication state changes.
+    /// </summary>
+    event Action? AuthStateChanged;
+
+    /// <summary>
+    /// Configures the GitHub PAT. The token is validated and stored securely.
+    /// </summary>
+    /// <param name="token">The GitHub Personal Access Token</param>
+    /// <returns>Result indicating success or failure with error message</returns>
+    Task<GitHubAuthResult> ConfigureTokenAsync(string token);
+
+    /// <summary>
+    /// Clears the stored GitHub token.
+    /// </summary>
+    void ClearToken();
+
+    /// <summary>
+    /// Gets the authenticated user's information.
+    /// </summary>
+    Task<GitHubUserDto?> GetCurrentUserAsync();
+
+    /// <summary>
+    /// Gets repositories accessible to the authenticated user.
+    /// </summary>
+    /// <param name="limit">Maximum number of repositories to return</param>
+    Task<List<GitHubRepositoryDto>> GetRepositoriesAsync(int limit = 30);
+
+    /// <summary>
+    /// Gets recent commits for a repository.
+    /// </summary>
+    /// <param name="owner">Repository owner</param>
+    /// <param name="repo">Repository name</param>
+    /// <param name="limit">Maximum number of commits to return</param>
+    Task<List<GitHubCommitDto>> GetRecentCommitsAsync(string owner, string repo, int limit = 30);
+
+    /// <summary>
+    /// Gets open pull requests for a repository.
+    /// </summary>
+    /// <param name="owner">Repository owner</param>
+    /// <param name="repo">Repository name</param>
+    /// <param name="limit">Maximum number of PRs to return</param>
+    Task<List<GitHubPullRequestDto>> GetPullRequestsAsync(string owner, string repo, int limit = 30);
+
+    /// <summary>
+    /// Gets branches for a repository.
+    /// </summary>
+    /// <param name="owner">Repository owner</param>
+    /// <param name="repo">Repository name</param>
+    Task<List<GitHubBranchDto>> GetBranchesAsync(string owner, string repo);
+}

--- a/src/Grigori.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Grigori.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Grigori.Infrastructure.Chunking;
 using Grigori.Infrastructure.Dependencies;
 using Grigori.Infrastructure.Embeddings;
 using Grigori.Infrastructure.FileWatching;
+using Grigori.Infrastructure.GitHub;
 using Grigori.Infrastructure.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,6 +26,10 @@ public static class ServiceCollectionExtensions
 
         // File watching
         services.AddSingleton<FileWatcher>();
+
+        // GitHub integration (singleton for token state management)
+        services.AddHttpClient("GitHub");
+        services.AddSingleton<IGitHubService, GitHubService>();
 
         // Note: HNSW index removed - using pgvector for vector similarity search
 

--- a/src/Grigori.Infrastructure/GitHub/GitHubService.cs
+++ b/src/Grigori.Infrastructure/GitHub/GitHubService.cs
@@ -1,0 +1,509 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Grigori.Contracts.Dtos.GitHub;
+using Grigori.Contracts.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Grigori.Infrastructure.GitHub;
+
+/// <summary>
+/// GitHub service implementation using Personal Access Token authentication.
+/// Token is stored encrypted in local app data.
+/// </summary>
+public class GitHubService : IGitHubService, IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<GitHubService> _logger;
+    private readonly string _tokenFilePath;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    private string? _token;
+    private GitHubUserDto? _cachedUser;
+
+    public bool IsAuthenticated => !string.IsNullOrEmpty(_token);
+    public event Action? AuthStateChanged;
+
+    public GitHubService(IHttpClientFactory httpClientFactory, ILogger<GitHubService> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient("GitHub");
+        _httpClient.BaseAddress = new Uri("https://api.github.com/");
+        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        _httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+        _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Grigori", "1.0"));
+
+        _logger = logger;
+        _tokenFilePath = GetTokenFilePath();
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true
+        };
+
+        // Try to load existing token on startup
+        LoadTokenFromStorage();
+    }
+
+    public async Task<GitHubAuthResult> ConfigureTokenAsync(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return GitHubAuthResult.Failed("Token cannot be empty");
+
+        // Validate the token by fetching user info
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        try
+        {
+            var response = await _httpClient.GetAsync("user");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = null;
+                var error = response.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.Unauthorized => "Invalid token or token has expired",
+                    System.Net.HttpStatusCode.Forbidden => "Token does not have required permissions",
+                    _ => $"GitHub API error: {response.StatusCode}"
+                };
+                return GitHubAuthResult.Failed(error);
+            }
+
+            var ghUser = await response.Content.ReadFromJsonAsync<GitHubApiUser>(_jsonOptions);
+            if (ghUser == null)
+                return GitHubAuthResult.Failed("Failed to parse user response");
+
+            var user = MapToUserDto(ghUser);
+
+            // Store token securely
+            _token = token;
+            _cachedUser = user;
+            SaveTokenToStorage(token);
+
+            _logger.LogInformation("GitHub authentication successful for user {User}", user.Login);
+            AuthStateChanged?.Invoke();
+
+            return GitHubAuthResult.Succeeded(user);
+        }
+        catch (HttpRequestException ex)
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+            _logger.LogError(ex, "Failed to validate GitHub token");
+            return GitHubAuthResult.Failed($"Network error: {ex.Message}");
+        }
+    }
+
+    public void ClearToken()
+    {
+        _token = null;
+        _cachedUser = null;
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+
+        try
+        {
+            if (File.Exists(_tokenFilePath))
+                File.Delete(_tokenFilePath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete token file");
+        }
+
+        _logger.LogInformation("GitHub token cleared");
+        AuthStateChanged?.Invoke();
+    }
+
+    public async Task<GitHubUserDto?> GetCurrentUserAsync()
+    {
+        if (!IsAuthenticated)
+            return null;
+
+        if (_cachedUser != null)
+            return _cachedUser;
+
+        try
+        {
+            var ghUser = await _httpClient.GetFromJsonAsync<GitHubApiUser>("user", _jsonOptions);
+            if (ghUser != null)
+            {
+                _cachedUser = MapToUserDto(ghUser);
+                return _cachedUser;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get current user");
+        }
+
+        return null;
+    }
+
+    public async Task<List<GitHubRepositoryDto>> GetRepositoriesAsync(int limit = 30)
+    {
+        if (!IsAuthenticated)
+            return [];
+
+        try
+        {
+            var repos = await _httpClient.GetFromJsonAsync<List<GitHubApiRepository>>(
+                $"user/repos?sort=pushed&per_page={limit}", _jsonOptions);
+
+            return repos?.Select(MapToRepoDto).ToList() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get repositories");
+            return [];
+        }
+    }
+
+    public async Task<List<GitHubCommitDto>> GetRecentCommitsAsync(string owner, string repo, int limit = 30)
+    {
+        if (!IsAuthenticated)
+            return [];
+
+        try
+        {
+            var commits = await _httpClient.GetFromJsonAsync<List<GitHubApiCommit>>(
+                $"repos/{owner}/{repo}/commits?per_page={limit}", _jsonOptions);
+
+            return commits?.Select(MapToCommitDto).ToList() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get commits for {Owner}/{Repo}", owner, repo);
+            return [];
+        }
+    }
+
+    public async Task<List<GitHubPullRequestDto>> GetPullRequestsAsync(string owner, string repo, int limit = 30)
+    {
+        if (!IsAuthenticated)
+            return [];
+
+        try
+        {
+            var prs = await _httpClient.GetFromJsonAsync<List<GitHubApiPullRequest>>(
+                $"repos/{owner}/{repo}/pulls?state=all&sort=updated&per_page={limit}", _jsonOptions);
+
+            return prs?.Select(MapToPrDto).ToList() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get pull requests for {Owner}/{Repo}", owner, repo);
+            return [];
+        }
+    }
+
+    public async Task<List<GitHubBranchDto>> GetBranchesAsync(string owner, string repo)
+    {
+        if (!IsAuthenticated)
+            return [];
+
+        try
+        {
+            // Get repo info for default branch
+            var repoInfo = await _httpClient.GetFromJsonAsync<GitHubApiRepository>(
+                $"repos/{owner}/{repo}", _jsonOptions);
+
+            var branches = await _httpClient.GetFromJsonAsync<List<GitHubApiBranch>>(
+                $"repos/{owner}/{repo}/branches", _jsonOptions);
+
+            return branches?.Select(b => new GitHubBranchDto(
+                b.Name,
+                b.Commit?.Sha ?? "",
+                b.Protected,
+                b.Name == repoInfo?.DefaultBranch
+            )).ToList() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get branches for {Owner}/{Repo}", owner, repo);
+            return [];
+        }
+    }
+
+    private static string GetTokenFilePath()
+    {
+        // Use LocalApplicationData on Windows, or home directory on Linux/macOS
+        var basePath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        // Fallback to home directory if LocalApplicationData is empty (common in Docker)
+        if (string.IsNullOrEmpty(basePath))
+        {
+            basePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+
+        // Final fallback to /tmp if still empty
+        if (string.IsNullOrEmpty(basePath))
+        {
+            basePath = Path.GetTempPath();
+        }
+
+        var grigoriPath = Path.Combine(basePath, ".grigori");
+        Directory.CreateDirectory(grigoriPath);
+        return Path.Combine(grigoriPath, ".github_token");
+    }
+
+    private void LoadTokenFromStorage()
+    {
+        try
+        {
+            if (!File.Exists(_tokenFilePath))
+                return;
+
+            var encryptedData = File.ReadAllBytes(_tokenFilePath);
+            var token = DecryptToken(encryptedData);
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                _token = token;
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                _logger.LogInformation("Loaded GitHub token from storage");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load GitHub token from storage");
+        }
+    }
+
+    private void SaveTokenToStorage(string token)
+    {
+        try
+        {
+            var encryptedData = EncryptToken(token);
+            File.WriteAllBytes(_tokenFilePath, encryptedData);
+            _logger.LogDebug("Saved GitHub token to storage");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save GitHub token to storage");
+        }
+    }
+
+    private static byte[] EncryptToken(string token)
+    {
+        var tokenBytes = Encoding.UTF8.GetBytes(token);
+
+        // Use DPAPI on Windows for secure storage
+        if (OperatingSystem.IsWindows())
+        {
+            return ProtectedData.Protect(tokenBytes, null, DataProtectionScope.CurrentUser);
+        }
+
+        // For non-Windows, use a simple obfuscation (not truly secure, but better than plaintext)
+        // In production, consider using platform-specific keychains
+        var entropy = Encoding.UTF8.GetBytes(Environment.MachineName + Environment.UserName);
+        using var aes = Aes.Create();
+        aes.Key = SHA256.HashData(entropy);
+        aes.GenerateIV();
+
+        using var ms = new MemoryStream();
+        ms.Write(aes.IV, 0, aes.IV.Length);
+        using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        {
+            cs.Write(tokenBytes, 0, tokenBytes.Length);
+        }
+        return ms.ToArray();
+    }
+
+    private static string? DecryptToken(byte[] encryptedData)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var tokenBytes = ProtectedData.Unprotect(encryptedData, null, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(tokenBytes);
+        }
+
+        // For non-Windows
+        var entropy = Encoding.UTF8.GetBytes(Environment.MachineName + Environment.UserName);
+        using var aes = Aes.Create();
+        aes.Key = SHA256.HashData(entropy);
+
+        var iv = new byte[16];
+        Array.Copy(encryptedData, 0, iv, 0, 16);
+        aes.IV = iv;
+
+        using var ms = new MemoryStream(encryptedData, 16, encryptedData.Length - 16);
+        using var cs = new CryptoStream(ms, aes.CreateDecryptor(), CryptoStreamMode.Read);
+        using var sr = new StreamReader(cs);
+        return sr.ReadToEnd();
+    }
+
+    #region API Response Mapping
+
+    private static GitHubUserDto MapToUserDto(GitHubApiUser u) => new(
+        u.Login,
+        u.Name,
+        u.AvatarUrl,
+        u.Email,
+        u.PublicRepos,
+        u.TotalPrivateRepos,
+        u.CreatedAt
+    );
+
+    private static GitHubRepositoryDto MapToRepoDto(GitHubApiRepository r) => new(
+        r.Id,
+        r.Name,
+        r.FullName,
+        r.Description,
+        r.DefaultBranch,
+        r.Private,
+        r.Language,
+        r.StargazersCount,
+        r.ForksCount,
+        r.OpenIssuesCount,
+        r.CreatedAt,
+        r.UpdatedAt,
+        r.PushedAt,
+        r.HtmlUrl,
+        r.CloneUrl
+    );
+
+    private static GitHubCommitDto MapToCommitDto(GitHubApiCommit c) => new(
+        c.Sha,
+        c.Sha[..7],
+        c.Commit?.Message ?? "",
+        c.Commit?.Author?.Name,
+        c.Commit?.Author?.Email,
+        c.Author?.AvatarUrl,
+        c.Commit?.Author?.Date ?? DateTime.UtcNow,
+        c.HtmlUrl,
+        c.Stats?.Additions ?? 0,
+        c.Stats?.Deletions ?? 0,
+        c.Files?.Count ?? 0
+    );
+
+    private static GitHubPullRequestDto MapToPrDto(GitHubApiPullRequest pr) => new(
+        pr.Number,
+        pr.Title,
+        pr.State,
+        pr.Body,
+        pr.User?.Login ?? "",
+        pr.User?.AvatarUrl,
+        pr.Head?.Ref ?? "",
+        pr.Base?.Ref ?? "",
+        pr.CreatedAt,
+        pr.UpdatedAt,
+        pr.MergedAt,
+        pr.ClosedAt,
+        pr.HtmlUrl,
+        pr.Additions,
+        pr.Deletions,
+        pr.ChangedFiles,
+        pr.Commits,
+        pr.Draft
+    );
+
+    #endregion
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}
+
+#region GitHub API Response Types
+
+internal class GitHubApiUser
+{
+    public string Login { get; set; } = "";
+    public string? Name { get; set; }
+    public string? AvatarUrl { get; set; }
+    public string? Email { get; set; }
+    public int PublicRepos { get; set; }
+    public int TotalPrivateRepos { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+internal class GitHubApiRepository
+{
+    public long Id { get; set; }
+    public string Name { get; set; } = "";
+    public string FullName { get; set; } = "";
+    public string? Description { get; set; }
+    public string DefaultBranch { get; set; } = "main";
+    public bool Private { get; set; }
+    public string? Language { get; set; }
+    public int StargazersCount { get; set; }
+    public int ForksCount { get; set; }
+    public int OpenIssuesCount { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? PushedAt { get; set; }
+    public string HtmlUrl { get; set; } = "";
+    public string CloneUrl { get; set; } = "";
+}
+
+internal class GitHubApiCommit
+{
+    public string Sha { get; set; } = "";
+    public GitHubApiCommitDetail? Commit { get; set; }
+    public GitHubApiUser? Author { get; set; }
+    public string HtmlUrl { get; set; } = "";
+    public GitHubApiCommitStats? Stats { get; set; }
+    public List<object>? Files { get; set; }
+}
+
+internal class GitHubApiCommitDetail
+{
+    public string Message { get; set; } = "";
+    public GitHubApiCommitAuthor? Author { get; set; }
+}
+
+internal class GitHubApiCommitAuthor
+{
+    public string Name { get; set; } = "";
+    public string Email { get; set; } = "";
+    public DateTime Date { get; set; }
+}
+
+internal class GitHubApiCommitStats
+{
+    public int Additions { get; set; }
+    public int Deletions { get; set; }
+}
+
+internal class GitHubApiPullRequest
+{
+    public int Number { get; set; }
+    public string Title { get; set; } = "";
+    public string State { get; set; } = "";
+    public string? Body { get; set; }
+    public GitHubApiUser? User { get; set; }
+    public GitHubApiBranchRef? Head { get; set; }
+    public GitHubApiBranchRef? Base { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? MergedAt { get; set; }
+    public DateTime? ClosedAt { get; set; }
+    public string HtmlUrl { get; set; } = "";
+    public int Additions { get; set; }
+    public int Deletions { get; set; }
+    public int ChangedFiles { get; set; }
+    public int Commits { get; set; }
+    public bool Draft { get; set; }
+}
+
+internal class GitHubApiBranchRef
+{
+    public string Ref { get; set; } = "";
+    public string Sha { get; set; } = "";
+}
+
+internal class GitHubApiBranch
+{
+    public string Name { get; set; } = "";
+    public GitHubApiBranchCommit? Commit { get; set; }
+    public bool Protected { get; set; }
+}
+
+internal class GitHubApiBranchCommit
+{
+    public string Sha { get; set; } = "";
+}
+
+#endregion

--- a/src/Grigori.Infrastructure/Grigori.Infrastructure.csproj
+++ b/src/Grigori.Infrastructure/Grigori.Infrastructure.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grigori.Mcp/Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Layout/MainLayout.razor
@@ -48,6 +48,11 @@
                     CLI
                 </MudNavLink>
             </MudNavGroup>
+            <MudNavGroup Title="Integrations" Icon="@Icons.Material.Filled.Extension" IconColor="Color.Info" Expanded="false">
+                <MudNavLink Href="integrations/github" Icon="@Icons.Custom.Brands.GitHub">
+                    GitHub
+                </MudNavLink>
+            </MudNavGroup>
         </MudNavMenu>
 
         <MudSpacer />

--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Settings.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Settings.razor
@@ -1,0 +1,304 @@
+@page "/integrations/github"
+@using Grigori.Contracts.Dtos.GitHub
+@using Grigori.Contracts.Interfaces
+@inject IGitHubService GitHubService
+@inject ISnackbar Snackbar
+
+<PageTitle>GitHub Integration - Grigori</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">GitHub Integration</MudText>
+
+<MudGrid Spacing="3">
+    @* GitHub Integration Card *@
+    <MudItem xs="12" md="6">
+        <MudCard Elevation="1">
+            <MudCardHeader>
+                <CardHeaderAvatar>
+                    <MudIcon Icon="@Icons.Custom.Brands.GitHub" Size="Size.Large" />
+                </CardHeaderAvatar>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.h6">GitHub Integration</MudText>
+                    <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                        Connect your GitHub account to unlock activity tracking features
+                    </MudText>
+                </CardHeaderContent>
+                <CardHeaderActions>
+                    @if (GitHubService.IsAuthenticated)
+                    {
+                        <MudChip T="string" Color="Color.Success" Size="Size.Small" Icon="@Icons.Material.Filled.CheckCircle">
+                            Connected
+                        </MudChip>
+                    }
+                    else
+                    {
+                        <MudChip T="string" Color="Color.Default" Size="Size.Small" Icon="@Icons.Material.Filled.LinkOff">
+                            Not Connected
+                        </MudChip>
+                    }
+                </CardHeaderActions>
+            </MudCardHeader>
+            <MudCardContent>
+                @if (GitHubService.IsAuthenticated && _user != null)
+                {
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Class="mb-4">
+                        <MudAvatar Size="Size.Large" Style="width: 64px; height: 64px;">
+                            <MudImage Src="@_user.AvatarUrl" Alt="@_user.Login" Style="width: 100%; height: 100%; object-fit: cover;" />
+                        </MudAvatar>
+                        <div>
+                            <MudText Typo="Typo.subtitle1">@(_user.Name ?? _user.Login)</MudText>
+                            <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                                @@@_user.Login
+                            </MudText>
+                            <MudStack Row="true" Spacing="2" Class="mt-1">
+                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                                    @_user.PublicRepos public repos
+                                </MudChip>
+                                @if (_user.PrivateRepos > 0)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">
+                                        @_user.PrivateRepos private repos
+                                    </MudChip>
+                                }
+                            </MudStack>
+                        </div>
+                    </MudStack>
+
+                    <MudAlert Severity="Severity.Success" Dense="true" Class="mb-3">
+                        Your GitHub account is connected. Activity features are now available.
+                    </MudAlert>
+
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Error"
+                               StartIcon="@Icons.Material.Filled.LinkOff"
+                               OnClick="DisconnectGitHub"
+                               Disabled="_loading">
+                        Disconnect
+                    </MudButton>
+                }
+                else
+                {
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mb-4">
+                        <MudText Typo="Typo.body2">
+                            To enable GitHub features, create a Personal Access Token (PAT) with the following scopes:
+                        </MudText>
+                        <MudList T="string" Dense="true" Class="mt-2">
+                            <MudListItem T="string" Icon="@Icons.Material.Filled.Check" IconColor="Color.Success">
+                                <code>repo</code> - Access repositories
+                            </MudListItem>
+                            <MudListItem T="string" Icon="@Icons.Material.Filled.Check" IconColor="Color.Success">
+                                <code>read:user</code> - Read user profile
+                            </MudListItem>
+                        </MudList>
+                    </MudAlert>
+
+                    <MudTextField @bind-Value="_tokenInput"
+                                  Label="Personal Access Token"
+                                  Variant="Variant.Outlined"
+                                  InputType="@(_showToken ? InputType.Text : InputType.Password)"
+                                  Placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                                  Adornment="Adornment.End"
+                                  AdornmentIcon="@(_showToken ? Icons.Material.Filled.VisibilityOff : Icons.Material.Filled.Visibility)"
+                                  OnAdornmentClick="() => _showToken = !_showToken"
+                                  Class="mb-3"
+                                  HelperText="Your token is stored securely on your machine" />
+
+                    <MudStack Row="true" Spacing="2">
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Link"
+                                   OnClick="ConnectGitHub"
+                                   Disabled="_loading || string.IsNullOrWhiteSpace(_tokenInput)">
+                            @if (_loading)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                                <span>Connecting...</span>
+                            }
+                            else
+                            {
+                                <span>Connect</span>
+                            }
+                        </MudButton>
+
+                        <MudButton Variant="Variant.Text"
+                                   Color="Color.Info"
+                                   StartIcon="@Icons.Material.Filled.OpenInNew"
+                                   Href="https://github.com/settings/tokens/new?description=Grigori&scopes=repo,read:user"
+                                   Target="_blank">
+                            Create Token
+                        </MudButton>
+                    </MudStack>
+                }
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+
+    @* Features Unlocked by GitHub *@
+    <MudItem xs="12" md="6">
+        <MudCard Elevation="1">
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.h6">Features</MudText>
+                    <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                        Features unlocked by GitHub integration
+                    </MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                <MudList T="string" Dense="true">
+                    <MudListItem T="string">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="width: 100%;">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.Timeline" Color="Color.Primary" />
+                                <div>
+                                    <MudText Typo="Typo.body1">Activity Feed</MudText>
+                                    <MudText Typo="Typo.caption" Style="color: var(--mud-palette-text-secondary);">
+                                        Recent commits, PRs, and branch activity
+                                    </MudText>
+                                </div>
+                            </MudStack>
+                            @if (GitHubService.IsAuthenticated)
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" />
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Lock" Color="Color.Default" />
+                            }
+                        </MudStack>
+                    </MudListItem>
+                    <MudDivider />
+                    <MudListItem T="string">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="width: 100%;">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.Whatshot" Color="Color.Warning" />
+                                <div>
+                                    <MudText Typo="Typo.body1">Hot Spots</MudText>
+                                    <MudText Typo="Typo.caption" Style="color: var(--mud-palette-text-secondary);">
+                                        Most frequently changed files
+                                    </MudText>
+                                </div>
+                            </MudStack>
+                            @if (GitHubService.IsAuthenticated)
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" />
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Lock" Color="Color.Default" />
+                            }
+                        </MudStack>
+                    </MudListItem>
+                    <MudDivider />
+                    <MudListItem T="string">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="width: 100%;">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.AutoAwesome" Color="Color.Secondary" />
+                                <div>
+                                    <MudText Typo="Typo.body1">AI Summaries</MudText>
+                                    <MudText Typo="Typo.caption" Style="color: var(--mud-palette-text-secondary);">
+                                        LLM-powered change summaries
+                                    </MudText>
+                                </div>
+                            </MudStack>
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info">Coming Soon</MudChip>
+                        </MudStack>
+                    </MudListItem>
+                    <MudDivider />
+                    <MudListItem T="string">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="width: 100%;">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                                <MudIcon Icon="@Icons.Material.Filled.MonitorHeart" Color="Color.Error" />
+                                <div>
+                                    <MudText Typo="Typo.body1">Project Pulse</MudText>
+                                    <MudText Typo="Typo.caption" Style="color: var(--mud-palette-text-secondary);">
+                                        Health and activity indicators
+                                    </MudText>
+                                </div>
+                            </MudStack>
+                            @if (GitHubService.IsAuthenticated)
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" />
+                            }
+                            else
+                            {
+                                <MudIcon Icon="@Icons.Material.Filled.Lock" Color="Color.Default" />
+                            }
+                        </MudStack>
+                    </MudListItem>
+                </MudList>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private string _tokenInput = "";
+    private bool _showToken = false;
+    private bool _loading = false;
+    private GitHubUserDto? _user;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (GitHubService.IsAuthenticated)
+        {
+            _user = await GitHubService.GetCurrentUserAsync();
+        }
+
+        GitHubService.AuthStateChanged += OnAuthStateChanged;
+    }
+
+    private async void OnAuthStateChanged()
+    {
+        if (GitHubService.IsAuthenticated)
+        {
+            _user = await GitHubService.GetCurrentUserAsync();
+        }
+        else
+        {
+            _user = null;
+        }
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task ConnectGitHub()
+    {
+        if (string.IsNullOrWhiteSpace(_tokenInput))
+            return;
+
+        _loading = true;
+        StateHasChanged();
+
+        try
+        {
+            var result = await GitHubService.ConfigureTokenAsync(_tokenInput);
+
+            if (result.Success)
+            {
+                _user = result.User;
+                _tokenInput = "";
+                Snackbar.Add($"Connected as {result.User?.Login}", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add(result.ErrorMessage ?? "Failed to connect", Severity.Error);
+            }
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void DisconnectGitHub()
+    {
+        GitHubService.ClearToken();
+        _user = null;
+        Snackbar.Add("GitHub disconnected", Severity.Info);
+    }
+
+    public void Dispose()
+    {
+        GitHubService.AuthStateChanged -= OnAuthStateChanged;
+    }
+}

--- a/tools/github-setup.md
+++ b/tools/github-setup.md
@@ -1,0 +1,100 @@
+# GitHub Integration Setup
+
+Grigori supports optional GitHub integration that unlocks activity tracking features like commit history, pull request monitoring, and repository analytics.
+
+## Quick Start
+
+1. **Create a GitHub Personal Access Token (PAT)**
+   - Go to https://github.com/settings/tokens/new
+   - Or click "Create Token" in Grigori's Settings page (it will open with correct scopes)
+
+2. **Configure Required Scopes**
+   - `repo` - Full control of private repositories (needed to access commit history and PRs)
+   - `read:user` - Read user profile information
+
+3. **Enter Token in Grigori**
+   - Open Grigori dashboard at http://localhost:5151
+   - Go to **Settings** in the sidebar
+   - Paste your token in the "Personal Access Token" field
+   - Click **Connect**
+
+## Creating a Personal Access Token
+
+### Step-by-Step Instructions
+
+1. Log in to your GitHub account
+2. Navigate to **Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)**
+3. Click **Generate new token** → **Generate new token (classic)**
+4. Configure the token:
+   - **Note**: Enter a descriptive name like "Grigori"
+   - **Expiration**: Choose based on your preference (90 days recommended)
+   - **Scopes**: Select the following:
+     - [x] `repo` (Full control of private repositories)
+     - [x] `read:user` (Read user profile data)
+5. Click **Generate token**
+6. **Copy the token immediately** - you won't be able to see it again!
+
+### Direct Link
+
+Use this link to create a token with the correct scopes pre-selected:
+
+```
+https://github.com/settings/tokens/new?description=Grigori&scopes=repo,read:user
+```
+
+## Token Storage
+
+Your GitHub token is stored securely on your local machine:
+
+- **Windows**: Encrypted using Windows Data Protection API (DPAPI)
+- **macOS/Linux**: Encrypted using AES-256 with machine-specific key
+
+Token location: `%LOCALAPPDATA%\Grigori\.github_token` (Windows) or `~/.local/share/Grigori/.github_token` (Unix)
+
+The token is:
+- Never transmitted anywhere except to GitHub's API
+- Automatically loaded on startup
+- Easily removable via the Settings page "Disconnect" button
+
+## Features Unlocked by GitHub Integration
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| Activity Feed | Recent commits, PRs, and branch activity | Available |
+| Hot Spots | Most frequently changed files/areas | Available |
+| Project Pulse | Repository health and activity indicators | Available |
+| AI Summaries | LLM-powered change summaries | Coming Soon |
+
+## Troubleshooting
+
+### "Invalid token or token has expired"
+- Verify the token is copied correctly (no extra spaces)
+- Check if the token has expired on GitHub
+- Regenerate the token if needed
+
+### "Token does not have required permissions"
+- Make sure both `repo` and `read:user` scopes are selected
+- Regenerate the token with correct scopes
+
+### Can't access private repositories
+- The `repo` scope is required for private repository access
+- For organization repositories, you may need SSO authorization
+
+## Revoking Access
+
+To disconnect Grigori from GitHub:
+
+1. In Grigori: Go to Settings → Click **Disconnect**
+2. On GitHub (optional): Go to Settings → Developer settings → Personal access tokens → Delete the Grigori token
+
+## Fine-Grained Tokens (Beta)
+
+GitHub's new fine-grained tokens are not yet fully supported. For now, please use classic Personal Access Tokens.
+
+## Security Considerations
+
+- Generate a dedicated token for Grigori (don't reuse tokens from other apps)
+- Use the minimum required scopes
+- Set an expiration date on your token
+- Regenerate tokens periodically
+- Never commit tokens to version control


### PR DESCRIPTION
## Summary

- Add `IGitHubService` interface and DTOs for GitHub API integration
- Implement `GitHubService` with secure token storage (DPAPI on Windows, AES-256 on Linux/macOS)
- Add GitHub integration page at `/integrations/github` in the dashboard
- Add "Integrations" nav group to sidebar
- Add setup documentation in `tools/github-setup.md`

## Features

- Token validation via GitHub API on configuration
- Encrypted local token storage (persists across app restarts)
- User profile display with avatar, repos count
- Methods ready for Activity Feed, Hot Spots, Project Pulse features
- "Create Token" link opens GitHub with correct scopes pre-selected

## Test plan

- [ ] Configure a GitHub PAT in the dashboard
- [ ] Verify token is validated and user info displays
- [ ] Disconnect and verify token is cleared
- [ ] Restart app and verify token persists (local run)

Closes #58