### PR TITLE
feat(dashboard): Add conditional UI based on GitHub auth state

### DIFF
--- a/src/Grigori.Mcp/Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Layout/MainLayout.razor
@@ -1,8 +1,10 @@
 @inherits LayoutComponentBase
 @inject DashboardService DashboardService
 @inject IBrowserViewportService BrowserViewportService
+@inject IGitHubService GitHubService
 @implements IAsyncDisposable
 @implements IBrowserViewportObserver
+@using Grigori.Contracts.Interfaces
 
 <MudThemeProvider Theme="_theme" IsDarkMode="true" />
 <MudPopoverProvider />
@@ -43,6 +45,20 @@
             <MudNavLink Href="dependencies" Icon="@Icons.Material.Filled.Extension" IconColor="Color.Success">
                 Dependencies
             </MudNavLink>
+            @if (GitHubService.IsAuthenticated)
+            {
+                <MudNavGroup Title="Activity" Icon="@Icons.Material.Filled.Timeline" IconColor="Color.Primary" Expanded="false">
+                    <MudNavLink Href="activity/feed" Icon="@Icons.Material.Filled.RssFeed">
+                        Activity Feed
+                    </MudNavLink>
+                    <MudNavLink Href="activity/hotspots" Icon="@Icons.Material.Filled.Whatshot">
+                        Hot Spots
+                    </MudNavLink>
+                    <MudNavLink Href="activity/pulse" Icon="@Icons.Material.Filled.MonitorHeart">
+                        Project Pulse
+                    </MudNavLink>
+                </MudNavGroup>
+            }
             <MudNavGroup Title="Tools" Icon="@Icons.Material.Filled.Build" IconColor="Color.Error" Expanded="false">
                 <MudNavLink Href="tools/cli" Icon="@Icons.Material.Filled.Terminal">
                     CLI
@@ -152,10 +168,19 @@
     {
         var stats = await DashboardService.GetIndexStatsAsync();
         _totalChunks = stats?.TotalChunks ?? 0;
+
+        // Subscribe to GitHub auth state changes to update nav menu
+        GitHubService.AuthStateChanged += OnAuthStateChanged;
+    }
+
+    private async void OnAuthStateChanged()
+    {
+        await InvokeAsync(StateHasChanged);
     }
 
     public async ValueTask DisposeAsync()
     {
         await BrowserViewportService.UnsubscribeAsync(this);
+        GitHubService.AuthStateChanged -= OnAuthStateChanged;
     }
 }

--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Activity/Feed.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Activity/Feed.razor
@@ -1,0 +1,29 @@
+@page "/activity/feed"
+
+<PageTitle>Activity Feed - Grigori</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">Activity Feed</MudText>
+
+<GitHubAuthRequired FeatureDescription="Connect your GitHub account to view recent commits, pull requests, and branch activity across your repositories.">
+    <MudAlert Severity="Severity.Info" Class="mb-4">
+        Activity Feed feature coming soon. This page will display recent commits, PRs, and branch activity.
+    </MudAlert>
+
+    <MudPaper Elevation="1" Class="pa-4">
+        <MudText Typo="Typo.h6" Class="mb-3">Coming Soon</MudText>
+        <MudList T="string" Dense="true">
+            <MudListItem T="string" Icon="@Icons.Material.Filled.Commit">
+                Recent commits across all repositories
+            </MudListItem>
+            <MudListItem T="string" Icon="@Icons.Material.Filled.MergeType">
+                Pull request activity and status
+            </MudListItem>
+            <MudListItem T="string" Icon="@Icons.Material.Filled.AccountTree">
+                Branch creation and deletion events
+            </MudListItem>
+            <MudListItem T="string" Icon="@Icons.Material.Filled.FilterList">
+                Filter by repository, author, or date range
+            </MudListItem>
+        </MudList>
+    </MudPaper>
+</GitHubAuthRequired>

--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Activity/HotSpots.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Activity/HotSpots.razor
@@ -1,0 +1,61 @@
+@page "/activity/hotspots"
+
+<PageTitle>Hot Spots - Grigori</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">Hot Spots</MudText>
+
+<GitHubAuthRequired FeatureDescription="Connect your GitHub account to identify the most frequently changed files and code areas in your repositories.">
+    <MudAlert Severity="Severity.Info" Class="mb-4">
+        Hot Spots analysis feature coming soon. This page will highlight areas of high activity in your codebase.
+    </MudAlert>
+
+    <MudGrid Spacing="3">
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudText Typo="Typo.h6" Class="mb-3">
+                    <MudIcon Icon="@Icons.Material.Filled.Whatshot" Class="mr-2" Color="Color.Warning" />
+                    Most Changed Files
+                </MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    Files with the highest commit frequency over time. These often indicate areas that may need refactoring or additional attention.
+                </MudText>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudText Typo="Typo.h6" Class="mb-3">
+                    <MudIcon Icon="@Icons.Material.Filled.BugReport" Class="mr-2" Color="Color.Error" />
+                    Bug-Prone Areas
+                </MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    Code areas with frequent bug fixes based on commit message analysis.
+                </MudText>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudText Typo="Typo.h6" Class="mb-3">
+                    <MudIcon Icon="@Icons.Material.Filled.Group" Class="mr-2" Color="Color.Info" />
+                    Collaboration Zones
+                </MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    Files modified by multiple contributors, potential coordination points.
+                </MudText>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudText Typo="Typo.h6" Class="mb-3">
+                    <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Class="mr-2" Color="Color.Success" />
+                    Growth Trends
+                </MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    Files and directories growing fastest over time.
+                </MudText>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+</GitHubAuthRequired>

--- a/src/Grigori.Mcp/Dashboard/Components/Pages/Activity/Pulse.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Pages/Activity/Pulse.razor
@@ -1,0 +1,75 @@
+@page "/activity/pulse"
+
+<PageTitle>Project Pulse - Grigori</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">Project Pulse</MudText>
+
+<GitHubAuthRequired FeatureDescription="Connect your GitHub account to monitor repository health and activity indicators across your projects.">
+    <MudAlert Severity="Severity.Info" Class="mb-4">
+        Project Pulse feature coming soon. This page will provide health and activity indicators for your repositories.
+    </MudAlert>
+
+    <MudGrid Spacing="3">
+        <MudItem xs="12" md="4">
+            <MudPaper Elevation="1" Class="pa-4" Style="text-align: center;">
+                <MudIcon Icon="@Icons.Material.Filled.Speed" Size="Size.Large" Color="Color.Primary" Class="mb-2" />
+                <MudText Typo="Typo.h6">Velocity</MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    Commits per day/week trends
+                </MudText>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="4">
+            <MudPaper Elevation="1" Class="pa-4" Style="text-align: center;">
+                <MudIcon Icon="@Icons.Material.Filled.Healing" Size="Size.Large" Color="Color.Success" Class="mb-2" />
+                <MudText Typo="Typo.h6">Health Score</MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    PR merge rate, issue resolution
+                </MudText>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="4">
+            <MudPaper Elevation="1" Class="pa-4" Style="text-align: center;">
+                <MudIcon Icon="@Icons.Material.Filled.Groups" Size="Size.Large" Color="Color.Secondary" Class="mb-2" />
+                <MudText Typo="Typo.h6">Contributors</MudText>
+                <MudText Typo="Typo.body2" Style="color: var(--mud-palette-text-secondary);">
+                    Active contributors this period
+                </MudText>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    <MudPaper Elevation="1" Class="pa-4 mt-4">
+        <MudText Typo="Typo.h6" Class="mb-3">Planned Indicators</MudText>
+        <MudGrid Spacing="2">
+            <MudItem xs="12" sm="6">
+                <MudList T="string" Dense="true">
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconColor="Color.Success">
+                        Commit frequency trends
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconColor="Color.Success">
+                        PR review turnaround time
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconColor="Color.Success">
+                        Issue open/close ratio
+                    </MudListItem>
+                </MudList>
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudList T="string" Dense="true">
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconColor="Color.Success">
+                        Code churn analysis
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconColor="Color.Success">
+                        Branch lifecycle tracking
+                    </MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconColor="Color.Success">
+                        Release cadence metrics
+                    </MudListItem>
+                </MudList>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+</GitHubAuthRequired>

--- a/src/Grigori.Mcp/Dashboard/Components/Shared/GitHubAuthRequired.razor
+++ b/src/Grigori.Mcp/Dashboard/Components/Shared/GitHubAuthRequired.razor
@@ -1,0 +1,34 @@
+@using Grigori.Contracts.Interfaces
+@inject IGitHubService GitHubService
+
+@if (!GitHubService.IsAuthenticated)
+{
+    <MudPaper Elevation="0" Class="pa-8" Style="background: var(--mud-palette-background-gray); border-radius: 12px;">
+        <MudStack AlignItems="AlignItems.Center" Spacing="4">
+            <MudIcon Icon="@Icons.Custom.Brands.GitHub" Size="Size.Large" Style="font-size: 4rem; opacity: 0.6;" />
+            <MudText Typo="Typo.h5">GitHub Connection Required</MudText>
+            <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 400px;">
+                @FeatureDescription
+            </MudText>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Link"
+                       Href="/integrations/github"
+                       Class="mt-2">
+                Connect GitHub
+            </MudButton>
+        </MudStack>
+    </MudPaper>
+}
+else
+{
+    @ChildContent
+}
+
+@code {
+    [Parameter]
+    public string FeatureDescription { get; set; } = "Connect your GitHub account to access this feature.";
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}


### PR DESCRIPTION
## Summary

- Update `MainLayout` to conditionally show Activity nav group when GitHub is authenticated
- Add `GitHubAuthRequired` shared component for auth gating on pages
- Add placeholder pages for Activity Feed, Hot Spots, and Project Pulse
- Subscribe to `AuthStateChanged` event for real-time nav menu updates

## How It Works

1. **Nav Menu**: Activity group (Feed, Hot Spots, Pulse) only appears when `IGitHubService.IsAuthenticated` is true
2. **Auth Gating**: Pages use `<GitHubAuthRequired>` component which shows a "Connect GitHub" prompt if not authenticated
3. **Real-time Updates**: When user connects/disconnects GitHub, nav menu updates immediately without page refresh

## Dependencies

- Requires #64 (GitHub PAT authentication) to be merged first

## Test Plan

- [ ] Without GitHub auth: Activity nav group should be hidden
- [ ] Connect GitHub in Integrations page
- [ ] Activity nav group should appear immediately
- [ ] Navigate to /activity/feed directly without auth - should show connect prompt
- [ ] Disconnect GitHub - Activity nav group should disappear

Closes #63