### PR TITLE
fix: Service lifetime mismatch causing stale data (#76)

### DIFF
--- a/src/Grigori.DataAccess/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Grigori.DataAccess/Extensions/ServiceCollectionExtensions.cs
@@ -8,10 +8,11 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddGrigoriDataAccess(this IServiceCollection services)
     {
-        services.AddSingleton<IChunkRepository, ChunkRepository>();
-        services.AddSingleton<IMetricsRepository, MetricsRepository>();
-        services.AddSingleton<IDashboardRepository, DashboardRepository>();
-        services.AddSingleton<IProjectRepository, ProjectRepository>();
+        // Repositories must be Scoped to match DbContext lifetime
+        services.AddScoped<IChunkRepository, ChunkRepository>();
+        services.AddScoped<IMetricsRepository, MetricsRepository>();
+        services.AddScoped<IDashboardRepository, DashboardRepository>();
+        services.AddScoped<IProjectRepository, ProjectRepository>();
         return services;
     }
 }

--- a/src/Grigori.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Grigori.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -20,8 +20,8 @@ public static class ServiceCollectionExtensions
         // Dependency tracking (singleton, must be registered first)
         services.AddSingleton<IDependencyTracker, DependencyTracker>();
 
-        // Metrics (singleton for thread-safe metrics tracking)
-        services.AddSingleton<IMetricsService, MetricsService>();
+        // Metrics (scoped to match repository lifetime)
+        services.AddScoped<IMetricsService, MetricsService>();
 
         // Chunking
         services.AddSingleton<ILanguageChunker, CSharpChunker>();
@@ -30,10 +30,10 @@ public static class ServiceCollectionExtensions
         // File watching
         services.AddSingleton<FileWatcher>();
 
-        // GitHub integration (singleton for token state management)
+        // GitHub integration (GitHubService singleton for token state, IndexingService scoped for repository access)
         services.AddHttpClient("GitHub");
         services.AddSingleton<IGitHubService, GitHubService>();
-        services.AddSingleton<IGitHubIndexingService, GitHubIndexingService>();
+        services.AddScoped<IGitHubIndexingService, GitHubIndexingService>();
 
         // Note: HNSW index removed - using pgvector for vector similarity search
 
@@ -52,10 +52,10 @@ public static class ServiceCollectionExtensions
             };
         });
 
-        // Feature services
-        services.AddSingleton<ISearchService, SearchService>();
-        services.AddSingleton<IIndexService, IndexService>();
-        services.AddSingleton<BenchmarkService>();
+        // Feature services (scoped to match repository lifetime)
+        services.AddScoped<ISearchService, SearchService>();
+        services.AddScoped<IIndexService, IndexService>();
+        services.AddScoped<BenchmarkService>();
 
         return services;
     }


### PR DESCRIPTION
## Summary
- Change repositories from Singleton to Scoped to match DbContext lifetime
- Change services that depend on repositories from Singleton to Scoped
- Fixes stale data appearing on page refresh

## Root Cause
Repositories and services were registered as Singletons but depended on the Scoped `DbContext`. When a Singleton captures a Scoped service, it holds onto that instance for the app's lifetime, causing EF Core's change tracker to return cached/stale data.

## Changes
**DataAccess (Singleton → Scoped):**
- `IChunkRepository`
- `IMetricsRepository`
- `IDashboardRepository`
- `IProjectRepository`

**Infrastructure (Singleton → Scoped):**
- `IMetricsService`
- `IGitHubIndexingService`
- `ISearchService`
- `IIndexService`
- `BenchmarkService`

## Test plan
- [ ] Verify page refresh shows current data
- [ ] Verify navigation between pages shows fresh data
- [ ] Run existing tests

Closes #76